### PR TITLE
Add 'id' property in Ocean+ChipModel

### DIFF
--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipModel.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipModel.swift
@@ -9,13 +9,20 @@ import OceanTokens
 
 extension Ocean {
     public struct ChipModel {
+        public let id: String?
         public let icon: UIImage?
         public let number: Int?
         public let title: String
         public let type: Ocean.ChipType
         public var status: Ocean.ChipStatus
         
-        public init(icon: UIImage? = nil, number: Int? = nil, title: String, type: Ocean.ChipType = .choice, status: Ocean.ChipStatus = .normal) {
+        public init(id: String? = nil,
+                    icon: UIImage? = nil,
+                    number: Int? = nil,
+                    title: String,
+                    type: Ocean.ChipType = .choice,
+                    status: Ocean.ChipStatus = .normal) {
+            self.id = id
             self.icon = icon
             self.number = number
             self.title = title


### PR DESCRIPTION
## Description

Add an 'id' optional property in Ocean+ChipModel to identify which chip has been selected by the user.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I builded and tested the app without adding id property in earlier uses of this class and the app worked as expected.

## Screenshots (if appropriate):

## Checklist:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] All new and existing tests passed
