### PR TITLE
fix: Hide badge when number is nil at ChipChoiceWithBadge

### DIFF
--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithBadge.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithBadge.swift
@@ -116,8 +116,11 @@ extension Ocean {
         
         private func updateUI() {
             self.label.text = self.text
+
+            self.badge.isHidden = true
             if let numberValue = self.number {
                 self.badge.number = numberValue
+                self.badge.isHidden = false
                 if numberValue == 0 {
                     self.badge.status = .neutral
                 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hide badge when number is nil at ChipChoiceWithBadge

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 8 - 2021-12-30 at 11 17 18](https://user-images.githubusercontent.com/95654372/147759855-01968a1a-da28-41cc-9ad0-9d1a7511b8d8.png)


## Checklist:

- [ ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if appropriate)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] All new and existing tests passed
