### PR TITLE
Fix: New OceanStackView to fix OceanSpacer

### DIFF
--- a/OceanComponents/Classes/Components/AlertBox/Ocean+AlertBox.swift
+++ b/OceanComponents/Classes/Components/AlertBox/Ocean+AlertBox.swift
@@ -80,8 +80,8 @@ extension Ocean {
             }
         }
         
-        private lazy var mainContentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainContentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.spacing = Ocean.size.spacingStackXxxs
                 stack.distribution = .fill
@@ -98,8 +98,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var contentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var contentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.spacing = Ocean.size.spacingStackXxs
                 stack.distribution = .fill
@@ -111,8 +111,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var messageStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var messageStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.spacing = 2
                 stack.distribution = .fill

--- a/OceanComponents/Classes/Components/Badge/Ocean+BadgeNumber.swift
+++ b/OceanComponents/Classes/Components/Badge/Ocean+BadgeNumber.swift
@@ -55,8 +55,8 @@ extension Ocean {
             self.heightAnchor.constraint(equalToConstant: self.size == .medium ? Constants.height : Constants.heightSmall)
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0

--- a/OceanComponents/Classes/Components/Badge/Ocean+BadgeText.swift
+++ b/OceanComponents/Classes/Components/Badge/Ocean+BadgeText.swift
@@ -31,8 +31,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0

--- a/OceanComponents/Classes/Components/Balance/Ocean+Balance.swift
+++ b/OceanComponents/Classes/Components/Balance/Ocean+Balance.swift
@@ -107,8 +107,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var titleStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var titleStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fillProportionally
             stack.spacing = 0
@@ -135,8 +135,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var headerStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var headerStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fillProportionally
             stack.alignment = .center
@@ -181,8 +181,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var listBalanceAvailableStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var listBalanceAvailableStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0
@@ -219,8 +219,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var listCurrentBalanceStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var listCurrentBalanceStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0
@@ -257,8 +257,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var listScheduleBluStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var listScheduleBluStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0
@@ -296,8 +296,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var listScheduleNotBluStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var listScheduleNotBluStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0
@@ -316,8 +316,8 @@ extension Ocean {
             return stack
         }()
         
-        private lazy var listStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var listStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fill
             stack.alignment = .fill
@@ -338,8 +338,8 @@ extension Ocean {
             return stack
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fillProportionally
             stack.spacing = 0

--- a/OceanComponents/Classes/Components/Balance/Ocean+Balance.swift
+++ b/OceanComponents/Classes/Components/Balance/Ocean+Balance.swift
@@ -110,7 +110,7 @@ extension Ocean {
         private lazy var titleStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .vertical
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.spacing = 0
             
             stack.add([
@@ -138,7 +138,7 @@ extension Ocean {
         private lazy var headerStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .horizontal
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.alignment = .center
             stack.spacing = 0
             stack.translatesAutoresizingMaskIntoConstraints = false
@@ -341,7 +341,7 @@ extension Ocean {
         private lazy var mainStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .vertical
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.spacing = 0
             
             stack.add([

--- a/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetCell.swift
+++ b/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetCell.swift
@@ -22,7 +22,7 @@ extension Ocean {
         private lazy var contentStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .horizontal
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.spacing = Ocean.size.borderRadiusLg
             stack.alignment = .center
             stack.translatesAutoresizingMaskIntoConstraints = false
@@ -45,7 +45,7 @@ extension Ocean {
         private lazy var labelsStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .vertical
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.alignment = .leading
             stack.addArrangedSubview(titleLabel)
             stack.addArrangedSubview(subtitleLabel)
@@ -70,7 +70,7 @@ extension Ocean {
         private lazy var chevronStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .vertical
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.alignment = .trailing
             stack.addArrangedSubview(chevronImageView)
             return stack

--- a/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetCell.swift
+++ b/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetCell.swift
@@ -19,8 +19,8 @@ extension Ocean {
         
         static let identifier = "bottomSheetCellIdentifier"
         
-        private lazy var contentStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var contentStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fillProportionally
             stack.spacing = Ocean.size.borderRadiusLg
@@ -42,8 +42,8 @@ extension Ocean {
             return imageView
         }()
         
-        private lazy var labelsStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var labelsStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fillProportionally
             stack.alignment = .leading
@@ -67,8 +67,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var chevronStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var chevronStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fillProportionally
             stack.alignment = .trailing

--- a/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetViewController.swift
+++ b/OceanComponents/Classes/Components/BottomSheet/Ocean+BottomSheetViewController.swift
@@ -16,10 +16,10 @@ extension Ocean {
             static let heightCellWithImages: CGFloat = 73
         }
         
-        private lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.axis = .vertical
             }
         }()
@@ -122,7 +122,7 @@ extension Ocean {
                 return 0
             }
             
-            let stackView = UIStackView { stack in
+            let stackView = Ocean.StackView { stack in
                 stack.axis = actionsAxis
                 stack.distribution = .fillEqually
                 stack.spacing = Ocean.size.spacingStackXs

--- a/OceanComponents/Classes/Components/Button/Ocean+ButtonPrimary.swift
+++ b/OceanComponents/Classes/Components/Button/Ocean+ButtonPrimary.swift
@@ -132,7 +132,7 @@ extension Ocean {
         }
         
         private func makeView() {
-            let contentStack = UIStackView()
+            let contentStack = Ocean.StackView()
             contentStack.translatesAutoresizingMaskIntoConstraints = false
             contentStack.axis = .horizontal
             contentStack.alignment = .center

--- a/OceanComponents/Classes/Components/Button/Ocean+ButtonPrimaryInverse.swift
+++ b/OceanComponents/Classes/Components/Button/Ocean+ButtonPrimaryInverse.swift
@@ -66,7 +66,7 @@ extension Ocean {
         private var height: CGFloat = 48
         private var fontSize: CGFloat = Ocean.font.fontSizeXs
         private var padding: CGFloat = Ocean.size.spacingInlineSm
-        private var stack: UIStackView!
+        private var stack: Ocean.StackView!
         private var label: UILabel!
         private var imageView: UIImageView!
         private var spinner: Ocean.CircularProgressIndicator!
@@ -133,7 +133,7 @@ extension Ocean {
         }
         
         private func makeView() {
-            let contentStack = UIStackView()
+            let contentStack = Ocean.StackView()
             contentStack.translatesAutoresizingMaskIntoConstraints = false
             contentStack.axis = .horizontal
             contentStack.alignment = .center

--- a/OceanComponents/Classes/Components/Button/Ocean+ButtonSecondary.swift
+++ b/OceanComponents/Classes/Components/Button/Ocean+ButtonSecondary.swift
@@ -66,7 +66,7 @@ extension Ocean {
         private var height: CGFloat = 48
         private var fontSize: CGFloat = Ocean.font.fontSizeXs
         private var padding: CGFloat = Ocean.size.spacingInlineSm
-        private var stack: UIStackView!
+        private var stack: Ocean.StackView!
         private var label: UILabel!
         private var imageView: UIImageView!
         private var spinner: Ocean.CircularProgressIndicator!
@@ -133,7 +133,7 @@ extension Ocean {
         }
         
         private func makeView() {
-            let contentStack = UIStackView()
+            let contentStack = Ocean.StackView()
             contentStack.translatesAutoresizingMaskIntoConstraints = false
             contentStack.axis = .horizontal
             contentStack.alignment = .center

--- a/OceanComponents/Classes/Components/Button/Ocean+ButtonText.swift
+++ b/OceanComponents/Classes/Components/Button/Ocean+ButtonText.swift
@@ -68,7 +68,7 @@ extension Ocean {
         private var height: CGFloat = 48
         private var fontSize: CGFloat = Ocean.font.fontSizeXs
         private var padding: CGFloat = Ocean.size.spacingInlineSm
-        private var stack: UIStackView!
+        private var stack: Ocean.StackView!
         private var label: UILabel!
         private var imageView: UIImageView!
         private var spinner: Ocean.CircularProgressIndicator!
@@ -135,7 +135,7 @@ extension Ocean {
         }
         
         private func makeView() {
-            let contentStack = UIStackView()
+            let contentStack = Ocean.StackView()
             contentStack.translatesAutoresizingMaskIntoConstraints = false
             contentStack.axis = .horizontal
             contentStack.alignment = .center

--- a/OceanComponents/Classes/Components/Card/Ocean+CardContent.swift
+++ b/OceanComponents/Classes/Components/Card/Ocean+CardContent.swift
@@ -73,8 +73,8 @@ extension Ocean {
         
         private lazy var badgeView = Ocean.Badge.number()
         
-        private lazy var topStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var topStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = Ocean.size.spacingStackXs
@@ -120,8 +120,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var bottomStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var bottomStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = Ocean.size.spacingStackXs
@@ -158,8 +158,8 @@ extension Ocean {
         
         private lazy var bottomDivider = Ocean.Divider(widthConstraint: self.widthAnchor)
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fill
             stack.spacing = 0

--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipChoice.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipChoice.swift
@@ -46,8 +46,8 @@ extension Ocean {
         
         public var onValueChange: ((Bool, ChipChoice) -> Void)? = nil
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 0

--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithBadge.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithBadge.swift
@@ -61,8 +61,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 6

--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithIcon.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipChoiceWithIcon.swift
@@ -61,8 +61,8 @@ extension Ocean {
             return view
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 6

--- a/OceanComponents/Classes/Components/Chips/Ocean+ChipFilter.swift
+++ b/OceanComponents/Classes/Components/Chips/Ocean+ChipFilter.swift
@@ -53,8 +53,8 @@ extension Ocean {
             return view
         }()
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.spacing = 6

--- a/OceanComponents/Classes/Components/DatePicker/Ocean+DatePicker.swift
+++ b/OceanComponents/Classes/Components/DatePicker/Ocean+DatePicker.swift
@@ -17,13 +17,13 @@ extension Ocean {
         var calendarContainer: UIView!
         var calendar: FSCalendar!
         var header: UIView!
-        var headerStack: UIStackView!
+        var headerStack: Ocean.StackView!
         var headerYear: UILabel!
         var headerDate: UILabel!
         var backView: UIImageView!
 
-        var calendarButtons: UIStackView!
-        var calendarBackForwardButtons: UIStackView!
+        var calendarButtons: Ocean.StackView!
+        var calendarBackForwardButtons: Ocean.StackView!
         var calendarContainerHeight: CGFloat = 473
         var calendarBodyHeight: CGFloat = 300
         var calendarHeaderHeight: CGFloat = 96
@@ -94,12 +94,12 @@ extension Ocean {
                 // Fallback on earlier versions
             }
 
-            headerStack = UIStackView { stack in
+            headerStack = Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.axis = .horizontal
                 stack.alignment = .fill
                 stack.addArrangedSubview(Spacer(space: Ocean.size.spacingInsetSm))
-                stack.addArrangedSubview(UIStackView { stack in
+                stack.addArrangedSubview(Ocean.StackView { stack in
                     stack.axis = .vertical
                     stack.alignment = .leading
                     stack.addArrangedSubview(Spacer(space: Ocean.size.spacingInsetXs))
@@ -151,12 +151,12 @@ extension Ocean {
         }
 
         func makeCalendarButtons() {
-            calendarButtons = UIStackView { stack in
+            calendarButtons = Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.alignment = .fill
                 stack.axis = .vertical
                 stack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackSm))
-                stack.addArrangedSubview(UIStackView { stack in
+                stack.addArrangedSubview(Ocean.StackView { stack in
                     stack.alignment = .trailing
                     stack.axis = .horizontal
                     stack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackXxs))
@@ -184,7 +184,7 @@ extension Ocean {
         }
 
         func makeBackForwardButtons() {
-            calendarBackForwardButtons = UIStackView { stack in
+            calendarBackForwardButtons = Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.alignment = .fill
                 stack.translatesAutoresizingMaskIntoConstraints = false

--- a/OceanComponents/Classes/Components/Input/Ocean+FilterViewController.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+FilterViewController.swift
@@ -18,8 +18,8 @@ extension Ocean {
         public var navigationBackgroundColor: UIColor? = Ocean.color.colorInterfaceLightPure
         public var navigationTintColor: UIColor = Ocean.color.colorBrandPrimaryPure
         
-        private lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.alignment = .fill
                 stack.distribution = .fillProportionally

--- a/OceanComponents/Classes/Components/Input/Ocean+FilterViewController.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+FilterViewController.swift
@@ -22,7 +22,7 @@ extension Ocean {
             Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.alignment = .fill
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.axis = .vertical
                 
                 stack.addArrangedSubview(Ocean.Input.search { input in

--- a/OceanComponents/Classes/Components/Input/Ocean+InputSearchField.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+InputSearchField.swift
@@ -16,12 +16,12 @@ extension Ocean {
     }
 
     public class InputSearchField: UIControl, UITextFieldDelegate {
-        var mainStack: UIStackView!
+        var mainStack: Ocean.StackView!
 
         public var textField: UITextField!
         private var imageView: UIImageView!
         private var imageCloseView: UIImageView!
-        private var hStack: UIStackView!
+        private var hStack: Ocean.StackView!
         private var backgroundView: UIView!
         
         public var placeholder: String = "" {
@@ -107,7 +107,7 @@ extension Ocean {
         }
 
         func makemainStack() {
-            mainStack = UIStackView()
+            mainStack = Ocean.StackView()
             mainStack.translatesAutoresizingMaskIntoConstraints = false
             mainStack.axis = .vertical
             mainStack.alignment = .fill
@@ -115,7 +115,7 @@ extension Ocean {
         }
 
         func makeHStack() {
-            hStack = UIStackView()
+            hStack = Ocean.StackView()
             hStack.translatesAutoresizingMaskIntoConstraints = false
             hStack.axis = .horizontal
             hStack.alignment = .fill

--- a/OceanComponents/Classes/Components/Input/Ocean+InputTextField.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+InputTextField.swift
@@ -17,16 +17,16 @@ extension Ocean {
     }
 
     public class InputTextField: UIControl, UITextFieldDelegate {
-        internal var mainStack: UIStackView!
+        internal var mainStack: Ocean.StackView!
         internal var labelTitle: UILabel!
         internal var textField: UITextField!
         internal var imageView: UIImageView!
         internal var labelError: UILabel!
         internal var labelHelper: UILabel!
-        internal var hStack: UIStackView!
+        internal var hStack: Ocean.StackView!
         internal var backgroundView: UIView!
-        internal var titleStackContent: UIStackView!
-        internal var titleStackView: UIStackView!
+        internal var titleStackContent: Ocean.StackView!
+        internal var titleStackView: Ocean.StackView!
         internal var infoIconImageView: UIImageView!
         
         private let errorEmpty = "..."
@@ -171,7 +171,7 @@ extension Ocean {
         }
 
         func makemainStack() {
-            mainStack = UIStackView()
+            mainStack = Ocean.StackView()
             mainStack.translatesAutoresizingMaskIntoConstraints = false
             mainStack.axis = .vertical
             mainStack.alignment = .fill
@@ -179,7 +179,7 @@ extension Ocean {
         }
 
         func makeHStack() {
-            hStack = UIStackView()
+            hStack = Ocean.StackView()
             hStack.translatesAutoresizingMaskIntoConstraints = false
             hStack.axis = .horizontal
             hStack.alignment = .fill
@@ -196,7 +196,7 @@ extension Ocean {
          
         func makeTitleStackContent() {
             makeTitleStackView()
-            titleStackContent = UIStackView()
+            titleStackContent = Ocean.StackView()
             titleStackContent.axis = .vertical
             titleStackContent.alignment = .leading
             titleStackContent.distribution = .fillProportionally
@@ -207,7 +207,7 @@ extension Ocean {
         func makeTitleStackView() {
             makeTitleLabel()
             makeInfoIconImageView()
-            titleStackView = UIStackView()
+            titleStackView = Ocean.StackView()
             titleStackView.axis = .horizontal
             titleStackView.alignment = .center
             titleStackView.distribution = .fill

--- a/OceanComponents/Classes/Components/Input/Ocean+InputTextField.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+InputTextField.swift
@@ -199,7 +199,7 @@ extension Ocean {
             titleStackContent = Ocean.StackView()
             titleStackContent.axis = .vertical
             titleStackContent.alignment = .leading
-            titleStackContent.distribution = .fillProportionally
+            titleStackContent.distribution = .fill
             titleStackContent.addArrangedSubview(Spacer(space: 5))
             titleStackContent.addArrangedSubview(titleStackView)
         }

--- a/OceanComponents/Classes/Components/Input/Ocean+InputTokenField.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+InputTokenField.swift
@@ -47,8 +47,8 @@ extension Ocean {
             return view
         }()
         
-        private lazy var contentStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var contentStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .vertical
             stack.distribution = .fillProportionally
             stack.spacing = 0
@@ -104,7 +104,7 @@ extension Ocean {
         }
     }
     
-    class OTPStackView: UIStackView, UITextFieldDelegate {
+    class OTPStackView: Ocean.StackView, UITextFieldDelegate {
         let numberOfFields = 4
         var textFieldsCollection: [OTPTextField] = []
         var showsWarningColor = false

--- a/OceanComponents/Classes/Components/Input/Ocean+InputTokenField.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+InputTokenField.swift
@@ -50,7 +50,7 @@ extension Ocean {
         private lazy var contentStack: Ocean.StackView = {
             let stack = Ocean.StackView()
             stack.axis = .vertical
-            stack.distribution = .fillProportionally
+            stack.distribution = .fill
             stack.spacing = 0
             stack.translatesAutoresizingMaskIntoConstraints = false
             
@@ -134,7 +134,7 @@ extension Ocean {
             self.isUserInteractionEnabled = true
             self.translatesAutoresizingMaskIntoConstraints = false
             self.contentMode = .center
-            self.distribution = .fillProportionally
+            self.distribution = .fill
             self.spacing = Ocean.size.spacingStackXxs
         }
         

--- a/OceanComponents/Classes/Components/Input/Ocean+TextArea.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+TextArea.swift
@@ -186,7 +186,7 @@ extension Ocean {
             titleStackContent = Ocean.StackView()
             titleStackContent.axis = .vertical
             titleStackContent.alignment = .leading
-            titleStackContent.distribution = .fillProportionally
+            titleStackContent.distribution = .fill
             titleStackContent.addArrangedSubview(Spacer(space: 5))
             titleStackContent.addArrangedSubview(titleStackView)
         }

--- a/OceanComponents/Classes/Components/Input/Ocean+TextArea.swift
+++ b/OceanComponents/Classes/Components/Input/Ocean+TextArea.swift
@@ -11,16 +11,16 @@ import OceanTokens
 
 extension Ocean {
     public class TextArea: UIControl, UITextViewDelegate {
-        public var mainStack: UIStackView!
+        public var mainStack: Ocean.StackView!
         public var textArea: UITextView!
         public var labelTitle: UILabel!
         public var labelError: UILabel!
         public var labelHelper: UILabel!
-        public var hStack: UIStackView!
+        public var hStack: Ocean.StackView!
         public var backgroundView: UIView!
         public var labelPlaceholder: UILabel!
-        public var titleStackContent: UIStackView!
-        public var titleStackView: UIStackView!
+        public var titleStackContent: Ocean.StackView!
+        public var titleStackView: Ocean.StackView!
         public var infoIconImageView: UIImageView!
         
         private var height: CGFloat = 78
@@ -144,7 +144,7 @@ extension Ocean {
         }
         
         func makemainStack() {
-            mainStack = UIStackView()
+            mainStack = Ocean.StackView()
             mainStack.translatesAutoresizingMaskIntoConstraints = false
             mainStack.axis = .vertical
             mainStack.alignment = .fill
@@ -152,7 +152,7 @@ extension Ocean {
         }
         
         func makeHStack() {
-            hStack = UIStackView()
+            hStack = Ocean.StackView()
             hStack.translatesAutoresizingMaskIntoConstraints = false
             hStack.axis = .horizontal
             hStack.alignment = .fill
@@ -183,7 +183,7 @@ extension Ocean {
         
         func makeTitleStackContent() {
             makeTitleStackView()
-            titleStackContent = UIStackView()
+            titleStackContent = Ocean.StackView()
             titleStackContent.axis = .vertical
             titleStackContent.alignment = .leading
             titleStackContent.distribution = .fillProportionally
@@ -194,7 +194,7 @@ extension Ocean {
         func makeTitleStackView() {
             makeLabel()
             makeInfoIconImageView()
-            titleStackView = UIStackView()
+            titleStackView = Ocean.StackView()
             titleStackView.axis = .horizontal
             titleStackView.alignment = .center
             titleStackView.distribution = .fill

--- a/OceanComponents/Classes/Components/OptionCard/Ocean+OptionCard.swift
+++ b/OceanComponents/Classes/Components/OptionCard/Ocean+OptionCard.swift
@@ -36,7 +36,7 @@ extension Ocean {
         public lazy var mainStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .horizontal
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.spacing = 0
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.isUserInteractionEnabled = true
@@ -51,7 +51,7 @@ extension Ocean {
         public lazy var headStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .vertical
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.spacing = 0
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 
@@ -95,7 +95,7 @@ extension Ocean {
         public lazy var contentStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .horizontal
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.spacing = 0
                 stack.alignment = .center
                 stack.translatesAutoresizingMaskIntoConstraints = false
@@ -164,7 +164,7 @@ extension Ocean {
         public lazy var textStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .vertical
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.spacing = 0
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 

--- a/OceanComponents/Classes/Components/OptionCard/Ocean+OptionCard.swift
+++ b/OceanComponents/Classes/Components/OptionCard/Ocean+OptionCard.swift
@@ -33,8 +33,8 @@ extension Ocean {
         
         private let generator = UISelectionFeedbackGenerator()
         
-        public lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        public lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.distribution = .fillProportionally
                 stack.spacing = 0
@@ -48,8 +48,8 @@ extension Ocean {
             }
         }()
         
-        public lazy var headStack: UIStackView = {
-            UIStackView { stack in
+        public lazy var headStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fillProportionally
                 stack.spacing = 0
@@ -92,8 +92,8 @@ extension Ocean {
             return view
         }()
         
-        public lazy var contentStack: UIStackView = {
-            UIStackView { stack in
+        public lazy var contentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.distribution = .fillProportionally
                 stack.spacing = 0
@@ -161,8 +161,8 @@ extension Ocean {
             return view
         }()
         
-        public lazy var textStack: UIStackView = {
-            UIStackView { stack in
+        public lazy var textStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fillProportionally
                 stack.spacing = 0

--- a/OceanComponents/Classes/Components/RadioButton/Ocean+RadioButton.swift
+++ b/OceanComponents/Classes/Components/RadioButton/Ocean+RadioButton.swift
@@ -14,9 +14,9 @@ extension Ocean {
         
         internal let generator = UISelectionFeedbackGenerator()
         
-        private var mainStack: UIStackView!
+        private var mainStack: Ocean.StackView!
         private var radioBkgView: UIControl!
-        private var radioStack: UIStackView!
+        private var radioStack: Ocean.StackView!
         private var textLabel: UILabel!
 
         public var label: String = "" {
@@ -117,18 +117,18 @@ extension Ocean {
         }
 
         func makeView() {
-            mainStack = UIStackView()
+            mainStack = Ocean.StackView()
             mainStack.translatesAutoresizingMaskIntoConstraints = false
             mainStack.axis = .vertical
             mainStack.alignment = .leading
             mainStack.distribution = .fillProportionally
             mainStack.isUserInteractionEnabled = true
 
-            radioStack = UIStackView()
+            radioStack = Ocean.StackView()
             radioStack.translatesAutoresizingMaskIntoConstraints = false
             radioStack.axis = .horizontal
             radioStack.alignment = .center
-            radioStack.distribution = .fillProportionally
+            radioStack.distribution = .fill
             mainStack.addArrangedSubview(radioStack)
 
             radioBkgView = UIControl()

--- a/OceanComponents/Classes/Components/RadioButton/Ocean+RadioButton.swift
+++ b/OceanComponents/Classes/Components/RadioButton/Ocean+RadioButton.swift
@@ -121,7 +121,7 @@ extension Ocean {
             mainStack.translatesAutoresizingMaskIntoConstraints = false
             mainStack.axis = .vertical
             mainStack.alignment = .leading
-            mainStack.distribution = .fillProportionally
+            mainStack.distribution = .fill
             mainStack.isUserInteractionEnabled = true
 
             radioStack = Ocean.StackView()
@@ -167,13 +167,7 @@ extension Ocean {
             self.isUserInteractionEnabled = true
             self.addGestureRecognizer(tapIconGesture)
 
-            mainStack.leftAnchor.constraint(equalTo: self.leftAnchor).isActive = true
-            mainStack.topAnchor.constraint(equalTo: self.topAnchor).isActive = true
-            mainStack.rightAnchor.constraint(equalTo: self.rightAnchor).isActive = true
-            mainStack.bottomAnchor.constraint(equalTo: self.bottomAnchor).isActive = true
-
-            radioStack.heightAnchor.constraint(equalToConstant: 24).isActive = true
-            radioStack.widthAnchor.constraint(equalTo: mainStack.widthAnchor).isActive = true
+            mainStack.setConstraints((.fillSuperView, toView: self))
 
             self.updateState()
         }

--- a/OceanComponents/Classes/Components/SnackBar/Ocean+Snackbar.swift
+++ b/OceanComponents/Classes/Components/SnackBar/Ocean+Snackbar.swift
@@ -95,7 +95,7 @@ extension Ocean {
             
             mainStack = Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.axis = .horizontal
                 stack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackXs))
                 stack.addArrangedSubview(imageViewIcon)

--- a/OceanComponents/Classes/Components/SnackBar/Ocean+Snackbar.swift
+++ b/OceanComponents/Classes/Components/SnackBar/Ocean+Snackbar.swift
@@ -14,7 +14,7 @@ extension Ocean {
     public typealias SnackbarBuilder = (Snackbar) -> Void
     
     public class Snackbar: UIView {
-        var mainStack: UIStackView!
+        var mainStack: Ocean.StackView!
         private var labelText: UILabel!
         private var imageViewIcon: UIImageView!
         private var actionText: String = "Action"
@@ -93,7 +93,7 @@ extension Ocean {
             self.layer.cornerRadius = Ocean.size.borderRadiusSm
             self.translatesAutoresizingMaskIntoConstraints = false
             
-            mainStack = UIStackView { stack in
+            mainStack = Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.distribution = .fillProportionally
                 stack.axis = .horizontal

--- a/OceanComponents/Classes/Components/Spacer/Ocean+Spacer.swift
+++ b/OceanComponents/Classes/Components/Spacer/Ocean+Spacer.swift
@@ -24,8 +24,9 @@ extension Ocean {
         public convenience init(space: CGFloat) {
             self.init(frame: .zero)
             self.space = space
-            translatesAutoresizingMaskIntoConstraints = false
+            self.backgroundColor = .clear
 
+            self.translatesAutoresizingMaskIntoConstraints = false
             self.heightAnchor.constraint(equalToConstant: space).isActive = true
             self.widthAnchor.constraint(equalToConstant: space).isActive = true
         }

--- a/OceanComponents/Classes/Components/Spacer/Ocean+Spacer.swift
+++ b/OceanComponents/Classes/Components/Spacer/Ocean+Spacer.swift
@@ -11,6 +11,8 @@ import OceanTokens
 
 extension Ocean {
     public class Spacer: UIView {
+        public var space: CGFloat = 0
+
         public override init(frame: CGRect) {
             super.init(frame: frame)
         }
@@ -21,49 +23,11 @@ extension Ocean {
 
         public convenience init(space: CGFloat) {
             self.init(frame: .zero)
+            self.space = space
             translatesAutoresizingMaskIntoConstraints = false
 
             self.heightAnchor.constraint(equalToConstant: space).isActive = true
             self.widthAnchor.constraint(equalToConstant: space).isActive = true
-        }
-
-        public convenience init(lessThan space: CGFloat) {
-            self.init(frame: .zero)
-            translatesAutoresizingMaskIntoConstraints = false
-
-            self.heightAnchor.constraint(lessThanOrEqualToConstant: space).isActive = true
-            self.widthAnchor.constraint(lessThanOrEqualToConstant: space).isActive = true
-
-            let constraints = self.heightAnchor.constraint(equalToConstant: space)
-            constraints.priority = .defaultLow
-            constraints.isActive = true
-        }
-
-        public convenience init(greaterThan space: CGFloat) {
-            self.init(frame: .zero)
-            translatesAutoresizingMaskIntoConstraints = false
-
-            self.heightAnchor.constraint(greaterThanOrEqualToConstant: space).isActive = true
-            self.widthAnchor.constraint(greaterThanOrEqualToConstant: space).isActive = true
-
-            let constraints = self.heightAnchor.constraint(equalToConstant: space)
-            constraints.priority = .defaultLow
-            constraints.isActive = true
-        }
-
-        public convenience init(lessThan less: CGFloat, greaterThan greater: CGFloat) {
-            self.init(frame: .zero)
-            translatesAutoresizingMaskIntoConstraints = false
-
-            self.heightAnchor.constraint(greaterThanOrEqualToConstant: greater).isActive = true
-            self.widthAnchor.constraint(greaterThanOrEqualToConstant: greater).isActive = true
-
-            self.heightAnchor.constraint(lessThanOrEqualToConstant: less).isActive = true
-            self.widthAnchor.constraint(lessThanOrEqualToConstant: less).isActive = true
-
-            let constraints = self.heightAnchor.constraint(equalToConstant: less)
-            constraints.priority = .defaultLow
-            constraints.isActive = true
         }
     }
 }

--- a/OceanComponents/Classes/Components/StackView/Ocean+StackView.swift
+++ b/OceanComponents/Classes/Components/StackView/Ocean+StackView.swift
@@ -1,0 +1,38 @@
+//
+//  Ocean+StackView.swift
+//  OceanComponents
+//
+//  Created by Leticia Fernandes on 03/02/22.
+//
+
+import Foundation
+import OceanTokens
+import UIKit
+
+extension Ocean {
+    public class StackView: UIStackView {
+
+        override public func addArrangedSubview(_ view: UIView) {
+            guard let spacerView = view as? Ocean.Spacer,
+                  self.distribution != .fillEqually,
+                  self.distribution != .fillProportionally else {
+                      super.addArrangedSubview(view)
+                      return
+                  }
+
+            let emptyView = UIView()
+            emptyView.backgroundColor = .clear
+            super.addArrangedSubview(emptyView)
+
+            switch self.axis {
+            case .vertical:
+                emptyView.setConstraints((.height(spacerView.space), toView: nil))
+            case .horizontal:
+                emptyView.setConstraints((.width(spacerView.space), toView: nil))
+            default: break
+            }
+            setNeedsLayout()
+            layoutIfNeeded()
+        }
+    }
+}

--- a/OceanComponents/Classes/Components/StackView/Ocean+StackView.swift
+++ b/OceanComponents/Classes/Components/StackView/Ocean+StackView.swift
@@ -20,19 +20,17 @@ extension Ocean {
                       return
                   }
 
-            let emptyView = UIView()
-            emptyView.backgroundColor = .clear
-            super.addArrangedSubview(emptyView)
+            spacerView.backgroundColor = .clear
+            super.addArrangedSubview(spacerView)
+            spacerView.removeConstraints(spacerView.constraints)
 
             switch self.axis {
             case .vertical:
-                emptyView.setConstraints((.height(spacerView.space), toView: nil))
+                spacerView.setConstraints((.height(spacerView.space), toView: nil))
             case .horizontal:
-                emptyView.setConstraints((.width(spacerView.space), toView: nil))
+                spacerView.setConstraints((.width(spacerView.space), toView: nil))
             default: break
             }
-            setNeedsLayout()
-            layoutIfNeeded()
         }
     }
 }

--- a/OceanComponents/Classes/Components/Subheader/Ocean+Subheader.swift
+++ b/OceanComponents/Classes/Components/Subheader/Ocean+Subheader.swift
@@ -66,8 +66,8 @@ extension Ocean {
             return self.heightAnchor.constraint(equalToConstant: Constants.heightMd)
         }()
         
-        private lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.distribution = .fill
                 stack.alignment = .center

--- a/OceanComponents/Classes/Components/Tag/Ocean+Tag.swift
+++ b/OceanComponents/Classes/Components/Tag/Ocean+Tag.swift
@@ -67,8 +67,8 @@ extension Ocean {
         
         private lazy var imageSpacer = Ocean.Spacer(space: Ocean.size.spacingStackXxxs)
         
-        private lazy var mainStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var mainStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.axis = .horizontal
             stack.distribution = .fill
             stack.alignment = .center

--- a/OceanComponents/Classes/Components/TextList/Ocean+TextListCell.swift
+++ b/OceanComponents/Classes/Components/TextList/Ocean+TextListCell.swift
@@ -74,8 +74,8 @@ extension Ocean {
 
         public var onTouch: (() -> Void)?
 
-        private lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fill
                 stack.translatesAutoresizingMaskIntoConstraints = false
@@ -92,8 +92,8 @@ extension Ocean {
             }
         }()
 
-        private lazy var contentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var contentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.distribution = .fill
                 stack.alignment = .center
@@ -151,8 +151,8 @@ extension Ocean {
 
         private lazy var badgeView = Ocean.Badge.text()
 
-        private lazy var infoStackTitle: UIStackView = {
-            UIStackView { stack in
+        private lazy var infoStackTitle: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.axis = .horizontal
                 stack.distribution = .fill
@@ -166,8 +166,8 @@ extension Ocean {
             }
         }()
 
-        private lazy var infoStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var infoStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 stack.axis = .vertical
                 stack.distribution = .fill

--- a/OceanComponents/Classes/Components/Tooltip/Ocean+Tooltip.swift
+++ b/OceanComponents/Classes/Components/Tooltip/Ocean+Tooltip.swift
@@ -46,8 +46,8 @@ extension Ocean {
         private var presenter = UIView()
         private var position: Position = .bottom
 
-        private lazy var contentStack: UIStackView = {
-            let stack = UIStackView()
+        private lazy var contentStack: Ocean.StackView = {
+            let stack = Ocean.StackView()
             stack.distribution = .fill
             stack.alignment = .fill
             stack.axis = .vertical

--- a/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
+++ b/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
@@ -219,7 +219,7 @@ extension Ocean {
         private lazy var contentStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .horizontal
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.alignment = .center
                 stack.spacing = Ocean.size.spacingStackXxxs
                 stack.translatesAutoresizingMaskIntoConstraints = false
@@ -244,7 +244,7 @@ extension Ocean {
         private lazy var mainStack: Ocean.StackView = {
             Ocean.StackView { stack in
                 stack.axis = .vertical
-                stack.distribution = .fillProportionally
+                stack.distribution = .fill
                 stack.translatesAutoresizingMaskIntoConstraints = false
                 
                 stack.add([

--- a/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
+++ b/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
@@ -148,8 +148,8 @@ extension Ocean {
         
         private lazy var level4Spacer = Ocean.Spacer(space: Ocean.size.spacingStackXxs)
         
-        private lazy var leftContentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var leftContentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fill
                 stack.alignment = .leading
@@ -197,8 +197,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var rightContentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var rightContentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fill
                 stack.alignment = .trailing
@@ -216,8 +216,8 @@ extension Ocean {
             }
         }()
         
-        private lazy var contentStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var contentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .horizontal
                 stack.distribution = .fillProportionally
                 stack.alignment = .center
@@ -241,8 +241,8 @@ extension Ocean {
         
         private lazy var divider = Ocean.Divider(widthConstraint: self.widthAnchor)
         
-        private lazy var mainStack: UIStackView = {
-            UIStackView { stack in
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
                 stack.axis = .vertical
                 stack.distribution = .fillProportionally
                 stack.translatesAutoresizingMaskIntoConstraints = false

--- a/OceanComponents/Classes/UIKit/Extensions/Builders/UIStackView+builder.swift
+++ b/OceanComponents/Classes/UIKit/Extensions/Builders/UIStackView+builder.swift
@@ -1,13 +1,15 @@
 //
-//  UIStackView+builder.swift
+//  Ocean.StackView+builder.swift
 //  OceanComponents
 //
 //  Created by Alex Gomes on 13/08/20.
 //
 
 import Foundation
-extension UIStackView {
-    public typealias BuilderStackView = (UIStackView) -> Void
+import OceanTokens
+
+extension Ocean.StackView {
+    public typealias BuilderStackView = (Ocean.StackView) -> Void
     
     convenience init(builder: BuilderStackView) {
         self.init()

--- a/OceanComponents/Classes/UIKit/Extensions/UIStackView+Extensions.swift
+++ b/OceanComponents/Classes/UIKit/Extensions/UIStackView+Extensions.swift
@@ -1,13 +1,14 @@
 //
-//  UIStackView+Extensions.swift
+//  Ocean.StackView+Extensions.swift
 //  OceanComponents
 //
 //  Created by Vini on 09/07/21.
 //
 
 import UIKit
+import OceanTokens
 
-extension UIStackView {
+extension Ocean.StackView {
     @discardableResult
     func removeAllArrangedSubviews() -> [UIView] {
         let removedSubviews = arrangedSubviews.reduce([]) { (removedSubviews, subview) -> [UIView] in

--- a/OceanDesignSystem/Controllers/Components/AlertBoxViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/AlertBoxViewController.swift
@@ -48,11 +48,11 @@ class AlertBoxViewController: UIViewController {
         alert.text = "This is a success message."
     }
     
-    lazy var contentStack: UIStackView = {
-        let contentStack = UIStackView()
+    lazy var contentStack: Ocean.StackView = {
+        let contentStack = Ocean.StackView()
         contentStack.axis = .vertical
         contentStack.spacing = Ocean.size.spacingStackXxs
-        contentStack.distribution = .fillProportionally
+        contentStack.distribution = .fill
         contentStack.alignment = .center
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         

--- a/OceanDesignSystem/Controllers/Components/BadgeViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/BadgeViewController.swift
@@ -40,7 +40,7 @@ final public class BadgeViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = Ocean.color.colorInterfaceLightUp
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.axis = .horizontal
         stack.distribution = .fill
         stack.alignment = .center

--- a/OceanDesignSystem/Controllers/Components/BalanceViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/BalanceViewController.swift
@@ -22,8 +22,8 @@ final public class BalanceViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
-        stack.distribution = .fillProportionally
+        let stack = Ocean.StackView()
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = 0
         

--- a/OceanDesignSystem/Controllers/Components/BottomSheetViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/BottomSheetViewController.swift
@@ -23,11 +23,11 @@ class BottomSheetViewController: UIViewController {
     
     private var showCase: ShowCases = .withActonsNormal
     
-    private lazy var contentStack: UIStackView = {
-        let contentStack = UIStackView()
+    private lazy var contentStack: Ocean.StackView = {
+        let contentStack = Ocean.StackView()
         contentStack.axis = .vertical
         contentStack.spacing = 30
-        contentStack.distribution = .fillProportionally
+        contentStack.distribution = .fill
         contentStack.alignment = .fill
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         

--- a/OceanDesignSystem/Controllers/Components/CardContentViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/CardContentViewController.swift
@@ -30,9 +30,9 @@ final public class CardContentViewController : UIViewController {
         spacer3.widthAnchor.constraint(equalToConstant: 220).isActive = true
         spacer3.heightAnchor.constraint(equalToConstant: 60).isActive = true
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.axis = .vertical
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.alignment = .center
         stack.spacing = Ocean.size.spacingStackXs
         stack.translatesAutoresizingMaskIntoConstraints = false

--- a/OceanDesignSystem/Controllers/Components/CardViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/CardViewController.swift
@@ -15,7 +15,7 @@ final public class CardViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = Ocean.color.colorInterfaceLightUp
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.axis = .vertical
         stack.distribution = .fill
         stack.alignment = .center

--- a/OceanDesignSystem/Controllers/Components/CarouselViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/CarouselViewController.swift
@@ -17,9 +17,9 @@ final public class CarouselViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = 0
         

--- a/OceanDesignSystem/Controllers/Components/CheckBoxViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/CheckBoxViewController.swift
@@ -36,9 +36,9 @@ final public class CheckBoxViewController : UIViewController {
             ck.isEnabled = false
         }
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         
@@ -54,7 +54,7 @@ final public class CheckBoxViewController : UIViewController {
     private func add(view: UIView) {
         self.view.addSubview(view)
         view.translatesAutoresizingMaskIntoConstraints = false
-        
+
         NSLayoutConstraint.activate([
             view.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
             view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)

--- a/OceanDesignSystem/Controllers/Components/CheckBoxViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/CheckBoxViewController.swift
@@ -53,11 +53,6 @@ final public class CheckBoxViewController : UIViewController {
     
     private func add(view: UIView) {
         self.view.addSubview(view)
-        view.translatesAutoresizingMaskIntoConstraints = false
-
-        NSLayoutConstraint.activate([
-            view.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
-            view.centerYAnchor.constraint(equalTo: self.view.centerYAnchor)
-        ])
+        view.setConstraints((.sameCenter, toView: self.view))
     }
 }

--- a/OceanDesignSystem/Controllers/Components/ChipsViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/ChipsViewController.swift
@@ -90,7 +90,7 @@ final public class ChipsViewController: UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = Ocean.color.colorInterfaceLightPure
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.axis = .vertical
         stack.distribution = .fill
         stack.alignment = .center

--- a/OceanDesignSystem/Controllers/Components/DatePickerViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/DatePickerViewController.swift
@@ -34,9 +34,9 @@ final public class DatePickerViewController : UIViewController {
             }
         }
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         

--- a/OceanDesignSystem/Controllers/Components/DividerViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/DividerViewController.swift
@@ -15,9 +15,9 @@ final public class DividerViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         

--- a/OceanDesignSystem/Controllers/Components/NavigationBarViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/NavigationBarViewController.swift
@@ -29,9 +29,9 @@ final public class NavigationBarViewController : UIViewController, OceanNavigati
         })])
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         

--- a/OceanDesignSystem/Controllers/Components/OptionCardViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/OptionCardViewController.swift
@@ -90,9 +90,9 @@ final public class OptionCardViewController : UIViewController {
             }
         }
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         

--- a/OceanDesignSystem/Controllers/Components/ProgressIndicatorViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/ProgressIndicatorViewController.swift
@@ -19,9 +19,9 @@ final public class ProgressIndicatorViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = Ocean.color.colorBrandPrimaryPure
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXs
         

--- a/OceanDesignSystem/Controllers/Components/RadioButtonViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/RadioButtonViewController.swift
@@ -42,9 +42,9 @@ final public class RadioButtonViewController : UIViewController {
             rb.isEnabled = false
         }
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = Ocean.size.spacingStackXxs
         

--- a/OceanDesignSystem/Controllers/Components/ShortcutViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/ShortcutViewController.swift
@@ -17,9 +17,9 @@ final public class ShortcutViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = 0
         

--- a/OceanDesignSystem/Controllers/Components/SubheaderViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/SubheaderViewController.swift
@@ -15,9 +15,9 @@ final public class SubheaderViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.axis = .vertical
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.alignment = .center
         stack.spacing = Ocean.size.spacingStackXs
         stack.translatesAutoresizingMaskIntoConstraints = false

--- a/OceanDesignSystem/Controllers/Components/SwitchViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/SwitchViewController.swift
@@ -29,9 +29,9 @@ final public class SwitchViewController : UIViewController {
             label.text = self.oceanSwitch.isOn.description
         }
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         
         stack.addArrangedSubview(oceanSwitch)

--- a/OceanDesignSystem/Controllers/Components/TagViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TagViewController.swift
@@ -70,7 +70,7 @@ final public class TagViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack1 = UIStackView()
+        let stack1 = Ocean.StackView()
         stack1.distribution = .fill
         stack1.axis = .vertical
         stack1.spacing = Ocean.size.spacingStackXs
@@ -84,7 +84,7 @@ final public class TagViewController : UIViewController {
         
         self.view.addSubview(stack1)
         
-        let stack2 = UIStackView()
+        let stack2 = Ocean.StackView()
         stack2.distribution = .fill
         stack2.axis = .vertical
         stack2.spacing = Ocean.size.spacingStackXs

--- a/OceanDesignSystem/Controllers/Components/TextListViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TextListViewController.swift
@@ -15,9 +15,9 @@ final public class TextListViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = 0
         

--- a/OceanDesignSystem/Controllers/Components/TooltipViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TooltipViewController.swift
@@ -11,11 +11,11 @@ import OceanTokens
 
 class TooltipViewController: UIViewController {
     
-    private lazy var contentStack: UIStackView = {
-        let contentStack = UIStackView()
+    private lazy var contentStack: Ocean.StackView = {
+        let contentStack = Ocean.StackView()
         contentStack.axis = .vertical
         contentStack.spacing = 0
-        contentStack.distribution = .fillProportionally
+        contentStack.distribution = .fill
         contentStack.alignment = .fill
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         
@@ -23,11 +23,11 @@ class TooltipViewController: UIViewController {
         return contentStack
     }()
     
-    private lazy var leftButtonExampleStack: UIStackView = {
-        let contentStack = UIStackView()
+    private lazy var leftButtonExampleStack: Ocean.StackView = {
+        let contentStack = Ocean.StackView()
         contentStack.axis = .vertical
         contentStack.spacing = 0
-        contentStack.distribution = .fillProportionally
+        contentStack.distribution = .fill
         contentStack.alignment = .leading
         contentStack.translatesAutoresizingMaskIntoConstraints = false
         

--- a/OceanDesignSystem/Controllers/Components/TransactionListViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TransactionListViewController.swift
@@ -15,9 +15,9 @@ final public class TransactionListViewController : UIViewController {
     public override func viewDidLoad() {
         self.view.backgroundColor = .white
         
-        let stack = UIStackView()
+        let stack = Ocean.StackView()
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         stack.axis = .vertical
         stack.spacing = 0
         


### PR DESCRIPTION
Fix OceanSpacer in StackViews all over the Ocean app.

## Description

It was created a new OceanStackView to be used all over the app, to fix OceanSpacer constraints, which are used all over the app.

From now on,  we should always use OceanStackView instead of UIStackView and always set the distribution property to '.fill', instead of '.fillProportionally' or '.fillEqually'.

Fixes # (issue)

OceanSpacer constraints was broken because it has width and height constraints and it was added inside stackViews.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed
