### PR TITLE
fix: Adjust labels ContentCompressionResistance at TransactionItemList

### DIFF
--- a/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
+++ b/OceanComponents/Classes/Components/TransactionList/Ocean+TransactionListItem.swift
@@ -107,8 +107,9 @@ extension Ocean {
                 label.font = .baseSemiBold(size: Ocean.font.fontSizeXs)
                 label.textAlignment = .left
                 label.textColor = Ocean.color.colorInterfaceDarkDeep
-                label.numberOfLines = 1
+                label.numberOfLines = 2
                 label.translatesAutoresizingMaskIntoConstraints = false
+                label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             }
         }()
 
@@ -121,6 +122,7 @@ extension Ocean {
                 label.textColor = Ocean.color.colorInterfaceDarkDown
                 label.numberOfLines = 1
                 label.translatesAutoresizingMaskIntoConstraints = false
+                label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             }
         }()
 
@@ -133,6 +135,7 @@ extension Ocean {
                 label.textColor = Ocean.color.colorInterfaceDarkUp
                 label.numberOfLines = 1
                 label.translatesAutoresizingMaskIntoConstraints = false
+                label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
             }
         }()
 
@@ -166,6 +169,22 @@ extension Ocean {
             }
         }()
 
+        private lazy var rightContentStack: Ocean.StackView = {
+            Ocean.StackView { stack in
+                stack.axis = .vertical
+                stack.distribution = .fill
+                stack.alignment = .trailing
+
+                stack.add([
+                    valueLabel,
+                    valueSpacer,
+                    tagView,
+                    tagSpacer,
+                    dateLabel
+                ])
+            }
+        }()
+
         private lazy var valueLabel: UILabel = {
             UILabel { label in
                 label.font = .baseBold(size: Ocean.font.fontSizeXxs)
@@ -173,6 +192,7 @@ extension Ocean {
                 label.textColor = Ocean.color.colorInterfaceDarkDeep
                 label.numberOfLines = 1
                 label.translatesAutoresizingMaskIntoConstraints = false
+                label.setContentCompressionResistancePriority(.required, for: .horizontal)
             }
         }()
 
@@ -193,27 +213,12 @@ extension Ocean {
                 label.textColor = Ocean.color.colorInterfaceDarkDown
                 label.numberOfLines = 1
                 label.translatesAutoresizingMaskIntoConstraints = false
+                label.setContentCompressionResistancePriority(.required, for: .horizontal)
+                label.adjustsFontSizeToFitWidth = true
+                label.minimumScaleFactor = 0.8
             }
         }()
 
-        private lazy var rightContentStack: Ocean.StackView = {
-            Ocean.StackView { stack in
-                stack.axis = .vertical
-                stack.distribution = .fill
-                stack.alignment = .trailing
-                stack.translatesAutoresizingMaskIntoConstraints = false
-
-                stack.add([
-                    valueLabel,
-                    valueSpacer,
-                    tagView,
-                    tagSpacer,
-                    dateLabel
-                ])
-
-                stack.widthAnchor.constraint(greaterThanOrEqualToConstant: 125).isActive = true
-            }
-        }()
 
         private lazy var contentStack: Ocean.StackView = {
             Ocean.StackView { stack in
@@ -221,7 +226,6 @@ extension Ocean {
                 stack.distribution = .fill
                 stack.alignment = .fill
                 stack.spacing = Ocean.size.spacingStackXxxs
-                stack.translatesAutoresizingMaskIntoConstraints = false
 
                 stack.add([
                     selectCheckBox,
@@ -245,7 +249,6 @@ extension Ocean {
                 stack.axis = .vertical
                 stack.distribution = .fill
                 stack.alignment = .fill
-                stack.translatesAutoresizingMaskIntoConstraints = false
 
                 stack.add([
                     contentStack,

--- a/OceanDesignSystem/Controllers/Components/TransactionListViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TransactionListViewController.swift
@@ -98,12 +98,25 @@ final public class TransactionListViewController : UIViewController {
                 view.hasCheckbox = !view.hasCheckbox
             }
         }
+
+        let transactionListItem6 = Ocean.TransactionListItem { view in
+            view.model = Ocean.TransactionListItem.Model(level1: "Maskel Indústria e Comércio de Colchões da Silva Sauro Industrial",
+                                                         value: 15000,
+                                                         valueStatus: .neutral,
+                                                         date: "Agendado 24 Jun 2021",
+                                                         withDivider: true)
+            view.onTouch = {
+                print("5")
+                view.hasCheckbox = !view.hasCheckbox
+            }
+        }
         
         stack.addArrangedSubview(transactionListItem1)
         stack.addArrangedSubview(transactionListItem2)
         stack.addArrangedSubview(transactionListItem3)
         stack.addArrangedSubview(transactionListItem4)
         stack.addArrangedSubview(transactionListItem5)
+        stack.addArrangedSubview(transactionListItem6)
         
         self.add(view: stack)
         
@@ -112,6 +125,7 @@ final public class TransactionListViewController : UIViewController {
         transactionListItem3.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
         transactionListItem4.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
         transactionListItem5.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
+        transactionListItem6.widthAnchor.constraint(equalTo: self.view.widthAnchor).isActive = true
     }
     
     private func add(view: UIView) {


### PR DESCRIPTION
 Adjust labels ContentCompressionResistance at TransactionItemList

## Description

- Adjust labels ContentCompressionResistance at TransactionItemList, higher priority to valueLabel and dateLabels.
- Set level1Label numberOfLines to 2.
- Add one more sample at TransactionListViewController.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):
<img width="358" alt="Screen Shot 2022-02-11 at 23 05 43" src="https://user-images.githubusercontent.com/95654372/153692173-ed46650e-32d4-4eed-b544-cf6051e7d8c2.png">

## Checklist:

- [x ] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x ] I have performed a self-review of my own code
- [x ] My changes generate no new warnings
- [x ] I have made corresponding changes to the documentation (if appropriate)
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] All new and existing tests passed
