### PR TITLE
fix: changed tab indicator to use constraint

### DIFF
--- a/OceanComponents/Classes/Components/Tab/Ocean+Tab.swift
+++ b/OceanComponents/Classes/Components/Tab/Ocean+Tab.swift
@@ -46,10 +46,24 @@ extension Ocean {
                 updateUI()
             }
         }
+        
+        private lazy var mainStack: Ocean.StackView = {
+            Ocean.StackView { stack in
+                stack.axis = .vertical
+                stack.distribution = .fill
+                stack.alignment = .fill
+                stack.spacing = 0
+                
+                stack.translatesAutoresizingMaskIntoConstraints = false
+            }
+        }()
 
         private lazy var containerView: UIView = {
             let view = UIView()
             view.backgroundColor = .clear
+            
+            view.translatesAutoresizingMaskIntoConstraints = false
+            
             return view
         }()
 
@@ -58,6 +72,8 @@ extension Ocean {
                 stack.axis = .horizontal
                 stack.distribution = .fill
                 stack.alignment = .fill
+                
+                stack.translatesAutoresizingMaskIntoConstraints = false
             }
         }()
 
@@ -65,22 +81,12 @@ extension Ocean {
             let view = UIView()
             return view
         }()
+        
+        private lazy var selectionLineViewLeadingConstraint: NSLayoutConstraint = {
+            return selectionLineView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
+        }()
 
         private lazy var divider = Ocean.Divider()
-
-        private lazy var mainStack: Ocean.StackView = {
-            Ocean.StackView { stack in
-                stack.axis = .vertical
-                stack.distribution = .fill
-                stack.alignment = .fill
-                stack.spacing = 0
-                stack.translatesAutoresizingMaskIntoConstraints = false
-
-                stack.add([
-                    containerView
-                ])
-            }
-        }()
 
         public convenience init(builder: TabViewBuilder = nil) {
             self.init()
@@ -106,21 +112,26 @@ extension Ocean {
 
         private func setupConstraints() {
             mainStack.setConstraints((.fillSuperView, toView: self))
-
-            containerView.addSubviews(tabStack,
-                                      divider,
-                                      selectionLineView)
+            
+            mainStack.add([containerView])
+            containerView.addSubviews(tabStack, selectionLineView, divider)
 
             tabStack.setConstraints(([.topToTop(.zero),
-                                      .horizontalMargin(.zero),
-                                      .height(Constants.tabHeight)], toView: containerView))
-
-            divider.setConstraints(([.bottomToBottom(.zero),
-                                     .horizontalMargin(.zero)], toView: containerView))
-
-            selectionLineView.setConstraints(([.topToBottom(.zero)], toView: tabStack),
-                                             ([.bottomToTop(.zero),
-                                               .height(Constants.lineHeight)], toView: divider))
+                                      .leadingToLeading(.zero),
+                                      .trailingToTrailing(.zero),
+                                      .height(Constants.tabHeight)], toView: containerView)
+            )
+            
+            selectionLineView.setConstraints(([.topToBottom(.zero),
+                                               .width(Constants.lineWidth),
+                                               .height(Constants.lineHeight)], toView: tabStack))
+            
+            divider.setConstraints(([.leadingToLeading(.zero),
+                                     .trailingToTrailing(.zero),
+                                     .bottomToBottom(.zero)], toView: containerView),
+                                   ([.topToBottom(.zero)], toView: selectionLineView))
+            
+            selectionLineViewLeadingConstraint.isActive = true
         }
 
         private func updateUI() {
@@ -131,7 +142,7 @@ extension Ocean {
             }
 
             let xPointLine = Constants.lineWidth * CGFloat(self.selectedIndex)
-            selectionLineView.frame.origin.x = xPointLine
+            selectionLineViewLeadingConstraint.constant = xPointLine
         }
 
         private func setupItemView(index: Int) -> UIView {

--- a/OceanDesignSystem/Controllers/Components/TabViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/TabViewController.swift
@@ -29,10 +29,8 @@ final public class TabViewController: UIViewController, OceanNavigationBar {
         self.view.backgroundColor = .white
 
         self.view.addSubview(self.tabView)
-        self.tabView.setConstraints(([.topToTop(0),
-                                      .horizontalMargin(.zero),
-                                      .height(58)],
+        self.tabView.setConstraints(([.topToTop(0), .horizontalMargin(.zero)],
                                      toView: self.view))
     }
-
+    
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Changed tab item indicator to use constraint to prevent an error when changing selected tab before view is presented.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):


https://user-images.githubusercontent.com/114941235/200009361-9e9fdd28-b3bc-4975-ad4e-613f214d53f8.mov


https://user-images.githubusercontent.com/114941235/200009367-b97cd629-4c53-4665-b4fa-b227d3d3d57a.mov



## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
