### PR TITLE
fix: tab indicator width due to multiple constraints

### DIFF
--- a/OceanComponents/Classes/Components/Tab/Ocean+Tab.swift
+++ b/OceanComponents/Classes/Components/Tab/Ocean+Tab.swift
@@ -23,8 +23,6 @@ extension Ocean {
         public var items: [OceanTabItem] = [] {
             didSet {
                 Constants.lineWidth = UIScreen.main.bounds.width / CGFloat(self.items.count)
-                selectionLineView.setConstraints((.width(Constants.lineWidth), toView: containerView))
-
                 updateUI()
             }
         }
@@ -82,6 +80,10 @@ extension Ocean {
             return view
         }()
         
+        private lazy var selectionLineViewWidthConstraint: NSLayoutConstraint = {
+            return selectionLineView.widthAnchor.constraint(equalToConstant: Constants.lineWidth)
+        }()
+        
         private lazy var selectionLineViewLeadingConstraint: NSLayoutConstraint = {
             return selectionLineView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor)
         }()
@@ -123,7 +125,6 @@ extension Ocean {
             )
             
             selectionLineView.setConstraints(([.topToBottom(.zero),
-                                               .width(Constants.lineWidth),
                                                .height(Constants.lineHeight)], toView: tabStack))
             
             divider.setConstraints(([.leadingToLeading(.zero),
@@ -131,6 +132,7 @@ extension Ocean {
                                      .bottomToBottom(.zero)], toView: containerView),
                                    ([.topToBottom(.zero)], toView: selectionLineView))
             
+            selectionLineViewWidthConstraint.isActive = true
             selectionLineViewLeadingConstraint.isActive = true
         }
 
@@ -141,6 +143,7 @@ extension Ocean {
                 self.tabStack.addArrangedSubview(itemView)
             }
 
+            selectionLineViewWidthConstraint.constant = Constants.lineWidth
             let xPointLine = Constants.lineWidth * CGFloat(self.selectedIndex)
             selectionLineViewLeadingConstraint.constant = xPointLine
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This fixes an error when a previous screen initializes the tab with a larger number than the actual one that would make the indicator with a smaller size.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screen Shot - iPhone 14 - 2022-11-04 at 17 40 50](https://user-images.githubusercontent.com/114941235/200071123-52ae4ca3-7718-4288-98c7-7f04e7dc33e0.png)

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
