### PR TITLE
fix: fixed shortcut spacing

### DIFF
--- a/OceanComponents/Classes/Components/Shortcut/Ocean+Shortcut.swift
+++ b/OceanComponents/Classes/Components/Shortcut/Ocean+Shortcut.swift
@@ -81,7 +81,7 @@ extension Ocean {
                     stack.addArrangedSubview(view)
                 }
 
-                if items.count < cols {
+                for _ in items.count..<cols {
                     stack.addArrangedSubview(UIView())
                 }
 

--- a/OceanDesignSystem/Controllers/Components/ShortcutViewController.swift
+++ b/OceanDesignSystem/Controllers/Components/ShortcutViewController.swift
@@ -43,7 +43,8 @@ final public class ShortcutViewController : UIViewController {
         addSection(stackView: contentStack, text: "Tiny - Horizontal")
         addExample(stack: contentStack,
                    orientation: .horizontal,
-                   size: .tiny)
+                   size: .tiny,
+                   cols: 3)
         addSection(stackView: contentStack, text: "Small - Vertical")
         addExample(stack: contentStack,
                    orientation: .vertical,
@@ -51,7 +52,8 @@ final public class ShortcutViewController : UIViewController {
         addSection(stackView: contentStack, text: "Medium - Vertical")
         addExample(stack: contentStack,
                    orientation: .vertical,
-                   size: .medium)
+                   size: .medium,
+                   cols: 3)
         addSection(stackView: contentStack, text: "Medium - Horizontal")
         addExample(stack: contentStack,
                    orientation: .horizontal,
@@ -87,13 +89,14 @@ final public class ShortcutViewController : UIViewController {
 
     public func addExample(stack: UIStackView,
                            orientation: Ocean.Shortcut.Orientation,
-                           size: Ocean.Shortcut.Size) {
+                           size: Ocean.Shortcut.Size,
+                           cols: Int = 2) {
 
         let view = Ocean.Shortcut()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.orientation = orientation
         view.size = size
-        view.set(data: examples, cols: 2)
+        view.set(data: examples, cols: cols)
         view.onTouch = { index in
             print(index)
         }


### PR DESCRIPTION
## Description

FIxed Shortcut spacing for rows with less items than specified column count

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 14 Pro - 2023-07-14 at 15 27 38](https://github.com/ocean-ds/ocean-ios/assets/114941235/d8244303-6f07-414d-8676-d4ce213e7621)

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
