### PR TITLE
fix: fixed multiple choice modal spacing

### DIFF
--- a/OceanComponents/Classes/Components/FilterBar/Ocean+FilterBar.swift
+++ b/OceanComponents/Classes/Components/FilterBar/Ocean+FilterBar.swift
@@ -75,17 +75,18 @@ extension Ocean {
         private func setupScrollView() {
             addSubview(scrollView)
             scrollView.addSubview(mainStack)
-            
+
             scrollView.oceanConstraints
                 .fill(to: self)
                 .height(constant: 64)
                 .make()
-            
-            NSLayoutConstraint.activate([
-                mainStack.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-                mainStack.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-                mainStack.centerYAnchor.constraint(equalTo: scrollView.centerYAnchor)
-            ])
+
+            mainStack.oceanConstraints
+                .topToTop(to: scrollView, constant: Ocean.size.spacingStackXs)
+                .bottomToBottom(to: scrollView, constant: -Ocean.size.spacingStackXs)
+                .leadingToLeading(to: scrollView)
+                .trailingToTrailing(to: scrollView)
+                .make()
         }
         
         public func addFilterChips(_ view: [FilterBarChipWithModal]) {

--- a/OceanComponents/Classes/Components/Modal/Ocean+ModelMultipleChoiceViewController.swift
+++ b/OceanComponents/Classes/Components/Modal/Ocean+ModelMultipleChoiceViewController.swift
@@ -35,14 +35,16 @@ extension Ocean {
         private lazy var optionsListCheckBox: [Ocean.CheckBox] = []
         
         lazy var contentStack: Ocean.StackView = {
-            let stack = Ocean.StackView()
-            stack.axis = .vertical
-            stack.distribution = .fill
-            stack.spacing = Ocean.size.spacingStackXxs
+            Ocean.StackView { stackView in
+                stackView.translatesAutoresizingMaskIntoConstraints = false
+                stackView.axis = .vertical
+                stackView.distribution = .fillEqually
+                stackView.alignment = .fill
+                stackView.spacing = Ocean.size.spacingStackXxs
 
-            stack.add(optionsListCheckBox)
+                stackView.add(optionsListCheckBox)
 
-            return stack
+            }
         }()
         
         private lazy var bottomStack: Ocean.StackView = {
@@ -109,7 +111,10 @@ extension Ocean {
             mainStack.addArrangedSubview(Spacer(space: bottomSpacing))
 
             let widthWithoutSpacing = view.frame.width - Ocean.size.spacingInsetLg
-            let totalLines = (label.frame.width / widthWithoutSpacing).rounded()
+
+            let labelEstimatedSize = label.text!.size(withAttributes: [.font: label.font!])
+            let totalLines = (labelEstimatedSize.width / widthWithoutSpacing).rounded(.up)
+
             return (totalLines * label.frame.height) + bottomSpacing
         }
         


### PR DESCRIPTION
## Description

Fixes # (issue)

Fixed vertical spacing error in multiple choice modal

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

Before fix:

https://github.com/ocean-ds/ocean-ios/assets/114941235/4eb064ce-e5c4-4390-8384-b9672983ce0d

After fix:

https://github.com/ocean-ds/ocean-ios/assets/114941235/8371c193-f07c-4241-8da0-0f7b7127f291

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
