### PR TITLE
Hotfix: fixed error in DatePicker and Input

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
+++ b/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
@@ -116,11 +116,11 @@ extension OceanSwiftUI {
             .autocapitalization(self.parameters.autocapitalization)
             .onReceive(Just(self.parameters.text), perform: { text in
                 let textMask = self.parameters.onMask?(text) ?? text
-                if textMask != self.textOld {
+                if textMask != self.textOld || text != self.textOld {
                     self.textOld = textMask
                     self.parameters.text = textMask
-                    self.parameters.onValueChanged(textMask)
                     self.parameters.errorMessage = ""
+                    self.parameters.onValueChanged(textMask)
                 }
             })
         }

--- a/OceanComponents/Classes/Components UIKit/DatePicker/Ocean+DatePicker.swift
+++ b/OceanComponents/Classes/Components UIKit/DatePicker/Ocean+DatePicker.swift
@@ -20,8 +20,6 @@ extension Ocean {
         public var navigationBackgroundColor: UIColor? = Ocean.color.colorInterfaceLightPure
         public var navigationTintColor: UIColor = Ocean.color.colorBrandPrimaryPure
 
-        private var dates: [Date] = []
-
         private lazy var backView: UIImageView = {
             let view = UIImageView(image: Ocean.icon.chevronLeftSolid)
             view.contentMode = .scaleAspectFit
@@ -108,15 +106,33 @@ extension Ocean {
             }
         }()
 
-        public var selectedDate = Date()
+        public var selectedDate = Date() {
+            didSet {
+                selectedDate = selectedDate.onlyDate
+            }
+        }
+
+        public var minimumDate = Date() {
+            didSet {
+                minimumDate = minimumDate.onlyDate
+            }
+        }
+
+        public var maximumDate = Date() {
+            didSet {
+                maximumDate = maximumDate.onlyDate
+            }
+        }
+
+        public var datesToHide: [Date] = [] {
+            didSet {
+                datesToHide = datesToHide.map { $0.onlyDate }
+            }
+        }
+
+        public var disableWeekend: Bool = true
         public var onReleaseCalendar: ((Date) -> Void)?
         public var onCancel: (() -> Void)?
-
-        public var currentDate = Date()
-        public var minimumDate = Date()
-        public var maximumDate = Date()
-        public var datesToHide: [Date] = []
-        public var disableWeekend: Bool = true
 
         public override func viewDidLoad() {
             super.viewDidLoad()
@@ -238,27 +254,12 @@ extension Ocean {
         }
 
         private func dateIsToday(date: Date) -> Bool {
-            getFormatedDate(date: date) == getFormatedDate(date: Date())
+            getFormatedDate(date: date) == getFormatedDate(date: Date().onlyDate)
         }
 
         private func loadDates() {
-            dates = datesRange(fromDate: minimumDate, toDate: maximumDate)
             calendar.reloadData()
-            calendar.select(minimumDate)
-        }
-
-        private func datesRange(fromDate: Date, toDate: Date) -> [Date] {
-            if fromDate > toDate { return [Date]() }
-
-            var tempDate = fromDate
-            var array = [tempDate]
-
-            while tempDate < toDate {
-                tempDate = Calendar.current.date(byAdding: .day, value: 1, to: tempDate)!
-                array.append(tempDate)
-            }
-
-            return array
+            calendar.select(selectedDate)
         }
 
         private func getFormatedDate(date: Date) -> String {
@@ -278,11 +279,15 @@ extension Ocean {
                 return false
             }
 
-            if dates.contains(date) {
+            if isInRange(date: date, minDate: minimumDate, maxDate: maximumDate) {
                 return true
             } else {
                 return false
             }
+        }
+
+        private func isInRange(date: Date, minDate: Date, maxDate: Date) -> Bool {
+            return date >= minDate && date <= maxDate
         }
     }
 }

--- a/OceanDesignSystem/Controllers/Components SwiftUI/InputSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/InputSwiftUIViewController.swift
@@ -47,6 +47,9 @@ final public class InputSwiftUIViewController : UIViewController {
             input.parameters.placeholder = "Placeholder"
             input.parameters.helperMessage = "Helper message"
             input.parameters.errorMessage = "Error message"
+            input.parameters.onValueChanged = { _ in
+                input.parameters.errorMessage = "New error message"
+            }
         }
     }()
 

--- a/OceanDesignSystem/Controllers/Components UIKit/ComponentsViewController.swift
+++ b/OceanDesignSystem/Controllers/Components UIKit/ComponentsViewController.swift
@@ -57,7 +57,8 @@ class ComponentsViewController: UITableViewController {
             datePicker.navigationTitle = "Agendar para"
             datePicker.minimumDate = Calendar.current.date(byAdding: .day, value: -10, to: Date())!
             datePicker.maximumDate = Calendar.current.date(byAdding: .day, value: 10, to: Date())!
-            datePicker.datesToHide = [Calendar.current.date(byAdding: .day, value: 2, to: Date())!]
+            datePicker.datesToHide = [Calendar.current.date(byAdding: .day, value: 1, to: Date())!]
+            datePicker.selectedDate = Date()
             datePicker.onCancel = {
                 print("DatePicker cancel")
             }


### PR DESCRIPTION
Fixes # (issue)

DatePicker
* Fixed an error in date handling that would cause a date being marked as unavailable because it had time components;
* Fixed an error in reporting a wrong selected date if the user has touched "Confirmar" without changing the selected date;
* Improved handling to start with the selected date instead of selecting the min date by default

Input
* Fixed an error that would not respect the mask length
* Fixed an error that would not show a error message if the error appeared during type

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

### DatePicker
* Fixed an error in date handling that would cause a date being marked as unavailable because it had time components;

Settings:

![Captura de Tela 2024-01-03 às 14 18 14](https://github.com/ocean-ds/ocean-ios/assets/114941235/74432d8d-d4e8-4c19-afbf-36ac80cbd5c1)

Before

https://github.com/ocean-ds/ocean-ios/assets/114941235/5b32a733-bed8-4934-ab24-951e9e728ff3

After

https://github.com/ocean-ds/ocean-ios/assets/114941235/f52a015c-4e01-4db2-9645-89498cdd57b6

* Fixed an error in reporting a wrong selected date if the user has touched "Confirmar" without changing the selected date;

Before

https://github.com/ocean-ds/ocean-ios/assets/114941235/20643777-8c56-49dc-8313-392bd26d0c48

After

https://github.com/ocean-ds/ocean-ios/assets/114941235/e7f31143-d943-43f1-b4c8-5b24288a367e


### Input
* Fixed an error that would not show a error message if the error appeared during type

Settings

![Captura de Tela 2024-01-03 às 14 20 39](https://github.com/ocean-ds/ocean-ios/assets/114941235/7d9231e8-1c3e-49d4-8445-4933748e4b95)

Before

https://github.com/ocean-ds/ocean-ios/assets/114941235/87b4fb9f-0fa9-4169-b43c-ab60deece037

After

https://github.com/ocean-ds/ocean-ios/assets/114941235/84d322f4-2152-473e-8943-845c14325cd0


## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
