### PR TITLE
fix: fixed wrong label in FilterBar and line limit in Tag

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/FilterBar/OceanSwiftUI+FilterBarOption.swift
+++ b/OceanComponents/Classes/Components SwiftUI/FilterBar/OceanSwiftUI+FilterBarOption.swift
@@ -19,7 +19,7 @@ extension OceanSwiftUI {
 
         public var isSelected: Bool { chips.contains { $0.isSelected } }
         public var label: String {
-            chips.count == 1 || !isSelected
+            chips.count == 1 || !isSelected || mode == .multiple
             ? title
             : chips.first { $0.isSelected }!.title
         }

--- a/OceanComponents/Classes/Components SwiftUI/Tag/OceanSwiftUI+Tag.swift
+++ b/OceanComponents/Classes/Components SwiftUI/Tag/OceanSwiftUI+Tag.swift
@@ -93,6 +93,7 @@ extension OceanSwiftUI {
                     OceanSwiftUI.Typography.caption { label in
                         label.parameters.textColor = self.getColor()
                         label.parameters.text = self.parameters.label
+                        label.parameters.lineLimit = 1
                     }
                 }
                 .padding(.horizontal, self.parameters.size == .medium ? Ocean.size.spacingStackXxs : Ocean.size.spacingStackXxxs)


### PR DESCRIPTION
## Description

Fixes an error in FilterBar that would change a item label when selecting multiple items;
Fixes an error in Tag that when a text is to lengthy would break line.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

https://github.com/ocean-ds/ocean-ios/assets/114941235/88cfffe5-f863-437d-b700-cef1ff9f824b

![Simulator Screenshot - iPhone 15 Pro - 2024-02-01 at 14 04 28](https://github.com/ocean-ds/ocean-ios/assets/114941235/5b1ae6c7-f3ff-4260-9d5c-158858345d40)

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
