### PR TITLE
fix: Fixed InvertedTextListItem skeleton height

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/InvertedTextListItem/OceanSwiftUI+InvertedTextListItem.swift
+++ b/OceanComponents/Classes/Components SwiftUI/InvertedTextListItem/OceanSwiftUI+InvertedTextListItem.swift
@@ -108,9 +108,7 @@ extension OceanSwiftUI {
                                       shape: .rounded(.radius(Ocean.size.borderRadiusSm,
                                                               style: .circular)))
                     }
-
-                    Spacer()
-                        .frame(height: parameters.padding.bottom)
+                    .frame(height: Constants.skeletonHeight)
                 } else {
                     HStack(spacing: 0) {
                         if let image = parameters.icon {


### PR DESCRIPTION
## Description

Fixes InvertedTextListItem skeleton height

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 15 Pro - 2024-03-20 at 15 32 16](https://github.com/ocean-ds/ocean-ios/assets/114941235/43144563-488c-47d2-853e-7c42a2ad8230)

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
