### PR TITLE
Fixes Modal height calculation, variable image size in OrderedListItem

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
+++ b/OceanComponents/Classes/Components SwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
@@ -23,6 +23,7 @@ extension OceanSwiftUI {
         @Published public var ctaText: String
         @Published public var ctaIcon: UIImage?
         @Published public var recommend: Bool
+        @Published public var showProgressText: Bool
         @Published public var isLoading: Bool
         public var onTouch: () -> Void
 
@@ -36,6 +37,7 @@ extension OceanSwiftUI {
                     ctaText: String = "",
                     ctaIcon: UIImage? = Ocean.icon.chevronRightSolid,
                     recommend: Bool = false,
+                    showProgressText: Bool = false,
                     isLoading: Bool = false,
                     onTouch: @escaping () -> Void = { }) {
             self.title = title
@@ -48,6 +50,7 @@ extension OceanSwiftUI {
             self.ctaText = ctaText
             self.ctaIcon = ctaIcon
             self.recommend = recommend
+            self.showProgressText = showProgressText
             self.isLoading = isLoading
             self.onTouch = onTouch
         }
@@ -138,6 +141,7 @@ extension OceanSwiftUI {
                     if let progress = parameters.progress {
                         ProgressBar { view in
                             view.parameters.progress = progress
+                            view.parameters.showValue = parameters.showProgressText
                             view.parameters.padding = EdgeInsets(top: 0,
                                                                  leading: Ocean.size.spacingStackXs,
                                                                  bottom: Ocean.size.spacingStackXs,

--- a/OceanComponents/Classes/Components UIKit/Modal/Ocean+ModalViewController.swift
+++ b/OceanComponents/Classes/Components UIKit/Modal/Ocean+ModalViewController.swift
@@ -37,69 +37,30 @@ extension Ocean {
         }
 
         public override func makeView() {
-            var totalSpacing = heightSpacing
-            totalSpacing += Ocean.size.spacingStackXxs
-            mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackXxs))
+            setupConstraints()
 
-            let topSpacing = Ocean.size.spacingStackMd
-            totalSpacing += topSpacing
+            mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackXxs))
 
             if swipeDismiss {
                 mainStack.addArrangedSubview(closeView)
             } else {
-                mainStack.addArrangedSubview(Spacer(space: topSpacing))
+                mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackMd))
             }
 
-            totalSpacing += addImageIfExist()
-            totalSpacing += addTitleIfExist()
-            totalSpacing += addDescriptionIfExist()
-            totalSpacing += addCustomViewIfExist()
-            totalSpacing += addActionsIfExist()
-            totalSpacing += addAdditionalInformationIfExist()
+            addImageIfExist()
+            addTitleIfExist()
+            addDescriptionIfExist()
+            addCustomViewIfExist()
+            addActionsIfExist()
+            addAdditionalInformationIfExist()
 
-            spTransitionDelegate.customHeight = totalSpacing
+            mainStack.layoutIfNeeded()
+            spTransitionDelegate.customHeight = mainStack.frame.height + Ocean.size.spacingStackSm
         }
 
-        fileprivate func addActionsIfExist() -> CGFloat {
-            guard !actions.isEmpty else {
-                return 0
-            }
-
-            let stackView = Ocean.StackView { stack in
-                stack.axis = actionsAxis
-                stack.distribution = .fillEqually
-                stack.spacing = Ocean.size.spacingStackXs
-                actions.forEach { (control) in
-                    stack.addArrangedSubview(control)
-                }
-            }
-
-            let actionsHeight: CGFloat = actionsAxis == .horizontal ? 48 : actions.count > 1 ? 112 : 48
-            let topSpacing = Ocean.size.spacingStackMd
-            let bottomSpacing = Ocean.size.spacingStackSm
-
-            mainStack.addArrangedSubview(Spacer(space: topSpacing))
-            mainStack.addArrangedSubview(stackView)
-            mainStack.addArrangedSubview(Spacer(space: bottomSpacing))
-
-            return actionsHeight + topSpacing + bottomSpacing
-        }
-
-        fileprivate func addCustomViewIfExist() -> CGFloat {
-            guard let customContent = self.customContent else {
-                return 0
-            }
-
-            customContent.sizeToFit()
-
-            mainStack.addArrangedSubview(customContent)
-
-            return customContent.frame.height
-        }
-
-        fileprivate func addImageIfExist() -> CGFloat {
+        fileprivate func addImageIfExist() {
             guard let image = contentImage else {
-                return 0
+                return
             }
 
             let imageView = UIImageView { imageView in
@@ -121,13 +82,11 @@ extension Ocean {
 
             mainStack.addArrangedSubview(imageView)
             mainStack.addArrangedSubview(Spacer(space: bottomSpacing))
-
-            return imageHeight + bottomSpacing
         }
 
-        fileprivate func addTitleIfExist() -> CGFloat {
+        fileprivate func addTitleIfExist() {
             guard let title = contentTitle else {
-                return 0
+                return
             }
 
             let label = Ocean.Typography.heading3 { label in
@@ -145,15 +104,11 @@ extension Ocean {
 
             mainStack.addArrangedSubview(label)
             mainStack.addArrangedSubview(Spacer(space: bottomSpacing))
-
-            let widthWithoutSpacing = view.frame.width - Ocean.size.spacingInsetLg
-            let totalLines = (label.frame.width / widthWithoutSpacing).rounded()
-            return (totalLines * label.frame.height) + bottomSpacing
         }
 
-        fileprivate func addDescriptionIfExist() -> CGFloat {
+        fileprivate func addDescriptionIfExist() {
             if contentDescription == nil && contentDescriptionAttributeText == nil {
-                return 0
+                return
             }
 
             let label = Ocean.Typography.paragraph { label in
@@ -173,15 +128,39 @@ extension Ocean {
             }
 
             mainStack.addArrangedSubview(label)
-
-            let widthWithoutSpacing = view.frame.width - Ocean.size.spacingInsetLg
-            let totalLines = (label.frame.width / widthWithoutSpacing).rounded()
-            return totalLines * label.frame.height
         }
 
-        fileprivate func addAdditionalInformationIfExist() -> CGFloat {
+        fileprivate func addCustomViewIfExist() {
+            guard let customContent = self.customContent else {
+                return
+            }
+
+            mainStack.addArrangedSubview(customContent)
+        }
+
+        fileprivate func addActionsIfExist() {
+            guard !actions.isEmpty else {
+                //                mainStack.addArrangedSubview(Ocean.Spacer(space: Ocean.size.spacingStackSm))
+                return
+            }
+
+            let stackView = Ocean.StackView { stack in
+                stack.axis = actionsAxis
+                stack.distribution = .fillEqually
+                stack.spacing = Ocean.size.spacingStackXs
+                actions.forEach { (control) in
+                    stack.addArrangedSubview(control)
+                }
+            }
+
+            mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackMd))
+            mainStack.addArrangedSubview(stackView)
+            mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackSm))
+        }
+
+        fileprivate func addAdditionalInformationIfExist() {
             guard let additionalInformation = contentAdditionalInformation else {
-                return 0
+                return
             }
 
             let label = Ocean.Typography.description { label in
@@ -193,28 +172,16 @@ extension Ocean {
                 label.sizeToFit()
             }
 
-            let bottomSpacing = Ocean.size.spacingStackXs
-
             mainStack.addArrangedSubview(label)
-            mainStack.addArrangedSubview(Spacer(space: bottomSpacing))
-
-            return label.frame.height + bottomSpacing
+            mainStack.addArrangedSubview(Spacer(space: Ocean.size.spacingStackXs))
         }
 
-        public override func viewDidLoad() {
-            super.viewDidLoad()
-            addConstraintMainStack()
-        }
-
-        private func addConstraintMainStack() {
-            NSLayoutConstraint.activate([
-                mainStack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-                mainStack.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor,
-                                                constant: Ocean.size.spacingStackSm),
-                mainStack.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor,
-                                                 constant: -Ocean.size.spacingStackSm),
-                mainStack.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
-            ])
+        private func setupConstraints() {
+            mainStack.oceanConstraints
+                .topToTop(to: view)
+                .centerX(to: view)
+                .width(constant: UIScreen.main.bounds.width - Ocean.size.spacingStackSm * 2)
+                .make()
         }
     }
 }

--- a/OceanComponents/Classes/Components UIKit/Modal/Ocean+ModalViewController.swift
+++ b/OceanComponents/Classes/Components UIKit/Modal/Ocean+ModalViewController.swift
@@ -140,7 +140,6 @@ extension Ocean {
 
         fileprivate func addActionsIfExist() {
             guard !actions.isEmpty else {
-                //                mainStack.addArrangedSubview(Ocean.Spacer(space: Ocean.size.spacingStackSm))
                 return
             }
 

--- a/OceanComponents/Classes/Components UIKit/OrderedList/Ocean+OrderedListItem.swift
+++ b/OceanComponents/Classes/Components UIKit/OrderedList/Ocean+OrderedListItem.swift
@@ -64,6 +64,19 @@ extension Ocean {
             }
         }
 
+        public var imageSize: CGSize = CGSize(width: Ocean.size.spacingInsetSm,
+                                              height: Ocean.size.spacingInsetSm) {
+            didSet {
+                imageView.removeConstraints(imageView.constraints)
+
+                imageView.oceanConstraints
+                    .center(to: roundedView)
+                    .width(constant: imageSize.width)
+                    .height(constant: imageSize.height)
+                    .make()
+            }
+        }
+
         private lazy var numberLabel: UILabel = {
             let label = UILabel()
             label.font = .baseSemiBold(size: Ocean.font.fontSizeXxs)
@@ -167,8 +180,8 @@ extension Ocean {
 
             imageView.oceanConstraints
                 .center(to: roundedView)
-                .width(constant: Ocean.size.spacingInsetSm)
-                .height(constant: Ocean.size.spacingInsetSm)
+                .width(constant: imageSize.width)
+                .height(constant: imageSize.height)
                 .make()
         }
 

--- a/OceanDesignSystem/Controllers/Components UIKit/ModalViewController.swift
+++ b/OceanDesignSystem/Controllers/Components UIKit/ModalViewController.swift
@@ -152,8 +152,14 @@ class ModalViewController: UIViewController {
     }()
     
     private lazy var customBottomSheet: Ocean.ModalViewController = {
-        Ocean.Modal(self)
-            .withCustomView(view: UIView())
+        let customView = UIView()
+        customView.oceanConstraints
+            .height(constant: 48)
+            .make()
+        customView.backgroundColor = UIColor.red
+
+        return Ocean.Modal(self)
+            .withCustomView(view: customView)
             .build()
     }()
     


### PR DESCRIPTION
## Description

Fixes Modal height calculation and added variable image size in OrderedListItem

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

https://github.com/ocean-ds/ocean-ios/assets/114941235/b168d440-b395-446f-806d-93b92b7312f8


## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
