### PR TITLE
fix: add dynamic height in error field

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
+++ b/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
@@ -302,7 +302,7 @@ extension OceanSwiftUI {
                         }
                     }
                 }
-                .frame(height: Ocean.size.spacingStackXs)
+                .frame(minHeight: Ocean.size.spacingStackXs)
                 .opacity(self.parameters.errorMessage.isEmpty && self.parameters.helperMessage.isEmpty ? 0 : 1)
 
                 Spacer()


### PR DESCRIPTION
## Description

Changes InputField error message height from fixed to minHeight to handle larger error messages

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 15 Pro - 2024-06-19 at 13 48 47](https://github.com/ocean-ds/ocean-ios/assets/114941235/2167d83c-3d28-4786-b82a-dd83f44c5ed2)


## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
