### PR TITLE
fix: add variable to toggle on/off fixed message height

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
+++ b/OceanComponents/Classes/Components SwiftUI/Input/OceanSwiftUI+InputTextField.swift
@@ -25,11 +25,13 @@ extension OceanSwiftUI {
         @Published public var iconHelper: UIImage?
         @Published public var keyboardType: UIKeyboardType
         @Published public var autocapitalization: UITextAutocapitalizationType
+        @Published public var autocorrectionDisabled: Bool
         @Published public var textContentType: UITextContentType?
         @Published public var maxLength: Int?
         @Published public var showMaxLength: Bool
         @Published public var isDisabled: Bool
         @Published public var showSkeleton: Bool
+        @Published public var reserveMessageHeight: Bool
         public var onMask: ((String) -> String)?
         public var onValueChanged: (String) -> Void
         public var onTouchIcon: () -> Void
@@ -46,11 +48,13 @@ extension OceanSwiftUI {
                     iconHelper: UIImage? = nil,
                     keyboardType: UIKeyboardType = .default,
                     autocapitalization: UITextAutocapitalizationType = .words,
+                    autocorrectionDisabled: Bool = false,
                     textContentType: UITextContentType? = nil,
                     maxLength: Int? = nil,
                     showMaxLength: Bool = false,
                     isDisabled: Bool = false,
                     showSkeleton: Bool = false,
+                    reserveMessageHeight: Bool = true,
                     onMask: ((String) -> String)? = nil,
                     onValueChanged: @escaping (String) -> Void = { _ in },
                     onTouchIcon: @escaping () -> Void = { },
@@ -66,11 +70,13 @@ extension OceanSwiftUI {
             self.iconHelper = iconHelper
             self.keyboardType = keyboardType
             self.autocapitalization = autocapitalization
+            self.autocorrectionDisabled = autocorrectionDisabled
             self.textContentType = textContentType
             self.maxLength = maxLength
             self.showMaxLength = showMaxLength
             self.isDisabled = isDisabled
             self.showSkeleton = showSkeleton
+            self.reserveMessageHeight = reserveMessageHeight
             self.onMask = onMask
             self.onValueChanged = onValueChanged
             self.onTouchIcon = onTouchIcon
@@ -204,6 +210,7 @@ extension OceanSwiftUI {
             }
             .disabled(self.parameters.isDisabled)
             .autocapitalization(self.parameters.autocapitalization)
+            .autocorrectionDisabled(self.parameters.autocorrectionDisabled)
             .onReceive(Just(self.parameters.text), perform: { text in
                 var textMask = self.parameters.onMask?(text) ?? text
                 if textMask != self.textOld || text != self.textOld {
@@ -303,7 +310,7 @@ extension OceanSwiftUI {
                         }
                     }
                 }
-                .frame(minHeight: Ocean.size.spacingStackXs)
+                .frame(minHeight: parameters.reserveMessageHeight ? Ocean.size.spacingStackXs : 0)
                 .opacity(self.parameters.errorMessage.isEmpty && self.parameters.helperMessage.isEmpty ? 0 : 1)
 
                 Spacer()


### PR DESCRIPTION
## Description

Adds parameter to toggle on/off height reservation for messages and also adds parameter to disable auto correction.

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 15 Pro - 2024-06-24 at 14 02 30](https://github.com/ocean-ds/ocean-ios/assets/114941235/a3dc6138-6062-4230-a562-f5360c989d7a)

## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
