### PR TITLE
fix: hide view when title is empty

### DIFF
--- a/OceanComponents/Classes/Components SwiftUI/InvertedTextListItem/OceanSwiftUI+InvertedTextListItem.swift
+++ b/OceanComponents/Classes/Components SwiftUI/InvertedTextListItem/OceanSwiftUI+InvertedTextListItem.swift
@@ -104,9 +104,11 @@ extension OceanSwiftUI {
         public var body: some View {
             VStack(alignment: .leading, spacing: 0) {
                 HStack(spacing: Ocean.size.spacingStackXxxs) {
-                    OceanSwiftUI.Typography.description { label in
-                        label.parameters.text = parameters.title
-                        label.parameters.textColor = Ocean.color.colorInterfaceDarkDown
+                    if !parameters.title.isEmpty {
+                        OceanSwiftUI.Typography.description { label in
+                            label.parameters.text = parameters.title
+                            label.parameters.textColor = Ocean.color.colorInterfaceDarkDown
+                        }
                     }
 
                     if !parameters.tooltipText.isEmpty {


### PR DESCRIPTION
## Description

Hides view in InvertedTextListItem when title is empty

Fixes # (issue)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

## Screenshots (if appropriate):

![Simulator Screenshot - iPhone 15 Pro - 2024-08-22 at 15 19 15](https://github.com/user-attachments/assets/f56babf8-f993-4a0b-b0c5-d4b1e15c27e4)


## Checklist:

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation (if appropriate)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] All new and existing tests passed
