### PR TITLE
feat(text-list-read-only): add OceanSwiftUI.TextListReadOnly composite

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0.1'
+          xcode-version: '26.1'
 
       - name: Set git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.0.1'
+          xcode-version: '26.1'
 
       - name: Set git identity
         run: |

--- a/OceanDesignSystem/Controllers/Components SwiftUI/ComponentsSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/ComponentsSwiftUIViewController.swift
@@ -99,6 +99,8 @@ class ComponentsSwiftUIViewController: UITableViewController {
             self.present(CardGroupSwiftUIViewController(), animated: true, completion: nil)
         case .TextListItem:
             self.present(TextListItemSwiftUIViewController(), animated: true, completion: nil)
+        case .TextListReadOnly:
+            self.present(TextListReadOnlySwiftUIViewController(), animated: true, completion: nil)
         case .Step:
             self.present(StepSwiftUIViewController(), animated: true, completion: nil)
         case .Tooltip:

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
@@ -16,7 +16,7 @@ class TextListReadOnlySwiftUIViewController: UIViewController {
     lazy var highlightLeadInverted: OceanSwiftUI.TextListReadOnly = {
         OceanSwiftUI.TextListReadOnly { view in
             view.parameters.contentList.type = .highlightLead
-            view.parameters.contentList.inverted = true
+            view.parameters.contentList.isInverted = true
             view.parameters.contentList.title = "Saldo total na Blu"
             view.parameters.contentList.description = "R$ 2.500,00"
         }

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
@@ -13,47 +13,50 @@ import SwiftUI
 
 class TextListReadOnlySwiftUIViewController: UIViewController {
 
-    lazy var invertedDefault: OceanSwiftUI.TextListReadOnly = {
+    lazy var highlightLeadInverted: OceanSwiftUI.TextListReadOnly = {
         OceanSwiftUI.TextListReadOnly { view in
-            view.parameters.contentList.type = .inverted
-            view.parameters.contentList.title = "R$ 2.500,00"
-            view.parameters.contentList.description = "Saldo total na Blu"
-        }
-    }()
-
-    lazy var invertedWithTag: OceanSwiftUI.TextListReadOnly = {
-        OceanSwiftUI.TextListReadOnly { view in
-            view.parameters.contentList.type = .inverted
-            view.parameters.contentList.title = "R$ 2.500,00"
-            view.parameters.contentList.description = "Saldo total na Blu"
-            view.parameters.tag = .init(label: "Novo",
-                                        status: .highlightNeutral,
-                                        size: .small)
-        }
-    }()
-
-    lazy var invertedWithIconAndDivider: OceanSwiftUI.TextListReadOnly = {
-        OceanSwiftUI.TextListReadOnly { view in
-            view.parameters.contentList.type = .inverted
-            view.parameters.contentList.title = "R$ 2.500,00"
-            view.parameters.contentList.description = "Saldo total na Blu"
-            view.parameters.showIcon = true
-            view.parameters.icon = Ocean.icon.placeholderSolid
-            view.parameters.showDivider = true
+            view.parameters.contentList.type = .highlightLead
+            view.parameters.contentList.inverted = true
+            view.parameters.contentList.title = "Saldo total na Blu"
+            view.parameters.contentList.description = "R$ 2.500,00"
         }
     }()
 
     lazy var defaultWithCaption: OceanSwiftUI.TextListReadOnly = {
         OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .default
             view.parameters.contentList.title = "Title"
             view.parameters.contentList.description = "Description"
             view.parameters.contentList.caption = "Caption"
         }
     }()
 
+    lazy var highlightWithTag: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .highlight
+            view.parameters.contentList.title = "Title"
+            view.parameters.contentList.description = "Description"
+            view.parameters.tag = .init(label: "Novo",
+                                        status: .highlightNeutral,
+                                        size: .small)
+        }
+    }()
+
+    lazy var defaultWithIconAndDivider: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .default
+            view.parameters.contentList.title = "Title"
+            view.parameters.contentList.description = "Description"
+            view.parameters.showIcon = true
+            view.parameters.icon = Ocean.icon.placeholderSolid
+            view.parameters.showDivider = true
+        }
+    }()
+
     lazy var disabled: OceanSwiftUI.TextListReadOnly = {
         OceanSwiftUI.TextListReadOnly { view in
             view.parameters.state = .disabled
+            view.parameters.contentList.type = .default
             view.parameters.contentList.title = "Title"
             view.parameters.contentList.description = "Description"
             view.parameters.contentList.caption = "Caption"
@@ -70,10 +73,10 @@ class TextListReadOnlySwiftUIViewController: UIViewController {
 
     public lazy var hostingController = UIHostingController(rootView: ScrollView {
         VStack(spacing: Ocean.size.spacingStackXs) {
-            invertedDefault
-            invertedWithTag
-            invertedWithIconAndDivider
+            highlightLeadInverted
             defaultWithCaption
+            highlightWithTag
+            defaultWithIconAndDivider
             disabled
             loading
         }

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
@@ -1,0 +1,103 @@
+//
+//  TextListReadOnlySwiftUIViewController.swift
+//  OceanDesignSystem
+//
+//  Created by Acassio Mendonça on 20/04/26.
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import Foundation
+import UIKit
+import OceanTokens
+import SwiftUI
+
+class TextListReadOnlySwiftUIViewController: UIViewController {
+
+    lazy var invertedDefault: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .inverted
+            view.parameters.contentList.title = "R$ 2.500,00"
+            view.parameters.contentList.description = "Saldo total na Blu"
+        }
+    }()
+
+    lazy var invertedWithIndicator: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .inverted
+            view.parameters.contentList.title = "R$ 2.500,00"
+            view.parameters.contentList.description = "Saldo total na Blu"
+            view.parameters.showIndicator = true
+            view.parameters.indicator = .init(label: "Novo",
+                                              status: .highlightNeutral,
+                                              size: .small)
+        }
+    }()
+
+    lazy var invertedWithIconAndDivider: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.type = .inverted
+            view.parameters.contentList.title = "R$ 2.500,00"
+            view.parameters.contentList.description = "Saldo total na Blu"
+            view.parameters.showIcon = true
+            view.parameters.icon = Ocean.icon.placeholderSolid
+            view.parameters.showDivider = true
+        }
+    }()
+
+    lazy var defaultWithCaption: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.contentList.title = "Title"
+            view.parameters.contentList.description = "Description"
+            view.parameters.contentList.caption = "Caption"
+        }
+    }()
+
+    lazy var disabled: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.state = .disabled
+            view.parameters.contentList.title = "Title"
+            view.parameters.contentList.description = "Description"
+            view.parameters.contentList.caption = "Caption"
+        }
+    }()
+
+    lazy var loading: OceanSwiftUI.TextListReadOnly = {
+        OceanSwiftUI.TextListReadOnly { view in
+            view.parameters.state = .loading
+            view.parameters.contentList.title = "Title"
+            view.parameters.contentList.description = "Description"
+        }
+    }()
+
+    public lazy var hostingController = UIHostingController(rootView: ScrollView {
+        VStack(spacing: Ocean.size.spacingStackXs) {
+            invertedDefault
+            invertedWithIndicator
+            invertedWithIconAndDivider
+            defaultWithCaption
+            disabled
+            loading
+        }
+    })
+
+    public lazy var uiView = self.hostingController.getUIView()
+
+    public override func viewDidLoad() {
+        self.view.backgroundColor = .white
+
+        self.view.addSubview(uiView)
+
+        uiView.oceanConstraints
+            .fill(to: self.view)
+            .make()
+    }
+}
+
+@available(iOS 13.0, *)
+struct TextListReadOnlySwiftUIViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        UIViewControllerPreview {
+            TextListReadOnlySwiftUIViewController()
+        }
+    }
+}

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TextListReadOnlySwiftUIViewController.swift
@@ -21,15 +21,14 @@ class TextListReadOnlySwiftUIViewController: UIViewController {
         }
     }()
 
-    lazy var invertedWithIndicator: OceanSwiftUI.TextListReadOnly = {
+    lazy var invertedWithTag: OceanSwiftUI.TextListReadOnly = {
         OceanSwiftUI.TextListReadOnly { view in
             view.parameters.contentList.type = .inverted
             view.parameters.contentList.title = "R$ 2.500,00"
             view.parameters.contentList.description = "Saldo total na Blu"
-            view.parameters.showIndicator = true
-            view.parameters.indicator = .init(label: "Novo",
-                                              status: .highlightNeutral,
-                                              size: .small)
+            view.parameters.tag = .init(label: "Novo",
+                                        status: .highlightNeutral,
+                                        size: .small)
         }
     }()
 
@@ -72,7 +71,7 @@ class TextListReadOnlySwiftUIViewController: UIViewController {
     public lazy var hostingController = UIHostingController(rootView: ScrollView {
         VStack(spacing: Ocean.size.spacingStackXs) {
             invertedDefault
-            invertedWithIndicator
+            invertedWithTag
             invertedWithIconAndDivider
             defaultWithCaption
             disabled

--- a/OceanDesignSystem/Enums/Enums.swift
+++ b/OceanDesignSystem/Enums/Enums.swift
@@ -122,6 +122,7 @@ public enum DesignSystemComponentsSwiftUIType: String {
     case Tab
     case Tag
     case TextListItem
+    case TextListReadOnly
     case Tooltip
     case TransactionFooter
     case TransactionListItem

--- a/OceanDesignSystem/Models/Components.swift
+++ b/OceanDesignSystem/Models/Components.swift
@@ -103,6 +103,7 @@ struct DSComponents {
         "Tab",
         "Tag",
         "TextListItem",
+        "TextListReadOnly",
         "InlineTextListItem",
         "CardReadOnly",
         "CardListExpandable",

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -110,11 +110,10 @@ extension OceanSwiftUI {
                             if !parameters.title.isEmpty {
                                 Typography.description { label in
                                     label.parameters.text = parameters.title
-                                    label.parameters.font = getTitleFont()
                                     label.parameters.textColor = getTitleColor()
                                 }
                             }
-
+                            
                             if !parameters.tagTitle.isEmpty {
                                 Tag { tag in
                                     tag.parameters.label = parameters.tagTitle
@@ -122,13 +121,13 @@ extension OceanSwiftUI {
                                 }
                             }
                         }
-
+                        
                         HStack(spacing: Ocean.size.spacingStackXxxs) {
                             if !parameters.description.isEmpty {
                                 Typography.paragraph { label in
                                     label.parameters.text = parameters.description
-                                    label.parameters.font = getDescriptionFont()
-
+                                    label.parameters.font = getFont()
+                                    
                                     if parameters.newDescription.isEmpty {
                                         label.parameters.textColor = getDescriptionColor()
                                     } else {
@@ -137,7 +136,7 @@ extension OceanSwiftUI {
                                     }
                                 }
                             }
-
+                            
                             if !parameters.newDescription.isEmpty {
                                 OceanSwiftUI.Typography.paragraph { label in
                                     label.parameters.text = parameters.newDescription
@@ -176,9 +175,16 @@ extension OceanSwiftUI {
         }
         
         // MARK: Private Methods
+        
+        private var resolvedInverted: Bool {
+            parameters.isInverted || parameters.type == .inverted
+        }
 
-        /// Cor base que a title assume quando o componente NAO esta invertido.
-        private func titleColorForType() -> UIColor {
+        private func getTitleColor() -> UIColor {
+            if resolvedInverted {
+                return Ocean.color.colorInterfaceDarkDown
+            }
+
             switch parameters.type {
             case .default:
                 return Ocean.color.colorInterfaceDarkPure
@@ -187,8 +193,7 @@ extension OceanSwiftUI {
             }
         }
 
-        /// Cor base que a description assume quando o componente NAO esta invertido.
-        private func descriptionColorForType() -> UIColor {
+        private func getDescriptionColor() -> UIColor {
             if let descriptionColor = parameters.descriptionColor {
                 return descriptionColor
             }
@@ -205,8 +210,7 @@ extension OceanSwiftUI {
             }
         }
 
-        /// Fonte base que a description assume quando o componente NAO esta invertido.
-        private func descriptionFontForType() -> UIFont? {
+        private func getFont() -> UIFont? {
             if let font = parameters.descriptionFont { return font }
 
             switch parameters.type {
@@ -217,37 +221,6 @@ extension OceanSwiftUI {
             default:
                 return .baseRegular(size: Ocean.font.fontSizeXs)
             }
-        }
-
-        /// Fonte base que a title assume quando o componente NAO esta invertido
-        /// (14pt regular, espelhando o default de Typography.description).
-        private func titleFontForType() -> UIFont? {
-            return .baseRegular(size: Ocean.font.fontSizeXxs)
-        }
-
-        // isInverted (novo): troca cor E fonte entre title/description.
-        // type == .inverted (legacy): continua trocando somente cores, sem mexer em fonte.
-
-        private func getTitleColor() -> UIColor {
-            if parameters.isInverted {
-                return descriptionColorForType()
-            }
-            return titleColorForType()
-        }
-
-        private func getDescriptionColor() -> UIColor {
-            if parameters.isInverted {
-                return titleColorForType()
-            }
-            return descriptionColorForType()
-        }
-
-        private func getTitleFont() -> UIFont? {
-            parameters.isInverted ? descriptionFontForType() : nil
-        }
-
-        private func getDescriptionFont() -> UIFont? {
-            parameters.isInverted ? titleFontForType() : descriptionFontForType()
         }
     }
 }

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -216,7 +216,7 @@ extension OceanSwiftUI {
             case .highlight:
                 return .baseBold(size: Ocean.font.fontSizeXs)
             case .highlightLead:
-                return .baseBold(size: Ocean.font.fontSizeMd)
+                return .baseBold(size: Ocean.font.fontSizeSm)
             default:
                 return .baseRegular(size: Ocean.font.fontSizeXs)
             }

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -110,10 +110,11 @@ extension OceanSwiftUI {
                             if !parameters.title.isEmpty {
                                 Typography.description { label in
                                     label.parameters.text = parameters.title
+                                    label.parameters.font = getTitleFont()
                                     label.parameters.textColor = getTitleColor()
                                 }
                             }
-                            
+
                             if !parameters.tagTitle.isEmpty {
                                 Tag { tag in
                                     tag.parameters.label = parameters.tagTitle
@@ -121,13 +122,13 @@ extension OceanSwiftUI {
                                 }
                             }
                         }
-                        
+
                         HStack(spacing: Ocean.size.spacingStackXxxs) {
                             if !parameters.description.isEmpty {
                                 Typography.paragraph { label in
                                     label.parameters.text = parameters.description
-                                    label.parameters.font = getFont()
-                                    
+                                    label.parameters.font = getDescriptionFont()
+
                                     if parameters.newDescription.isEmpty {
                                         label.parameters.textColor = getDescriptionColor()
                                     } else {
@@ -136,7 +137,7 @@ extension OceanSwiftUI {
                                     }
                                 }
                             }
-                            
+
                             if !parameters.newDescription.isEmpty {
                                 OceanSwiftUI.Typography.paragraph { label in
                                     label.parameters.text = parameters.newDescription
@@ -175,16 +176,9 @@ extension OceanSwiftUI {
         }
         
         // MARK: Private Methods
-        
-        private var resolvedInverted: Bool {
-            parameters.isInverted || parameters.type == .inverted
-        }
 
-        private func getTitleColor() -> UIColor {
-            if resolvedInverted {
-                return Ocean.color.colorInterfaceDarkDown
-            }
-
+        /// Cor base que a title assume quando o componente NAO esta invertido.
+        private func titleColorForType() -> UIColor {
             switch parameters.type {
             case .default:
                 return Ocean.color.colorInterfaceDarkPure
@@ -193,7 +187,8 @@ extension OceanSwiftUI {
             }
         }
 
-        private func getDescriptionColor() -> UIColor {
+        /// Cor base que a description assume quando o componente NAO esta invertido.
+        private func descriptionColorForType() -> UIColor {
             if let descriptionColor = parameters.descriptionColor {
                 return descriptionColor
             }
@@ -210,7 +205,8 @@ extension OceanSwiftUI {
             }
         }
 
-        private func getFont() -> UIFont? {
+        /// Fonte base que a description assume quando o componente NAO esta invertido.
+        private func descriptionFontForType() -> UIFont? {
             if let font = parameters.descriptionFont { return font }
 
             switch parameters.type {
@@ -221,6 +217,37 @@ extension OceanSwiftUI {
             default:
                 return .baseRegular(size: Ocean.font.fontSizeXs)
             }
+        }
+
+        /// Fonte base que a title assume quando o componente NAO esta invertido
+        /// (14pt regular, espelhando o default de Typography.description).
+        private func titleFontForType() -> UIFont? {
+            return .baseRegular(size: Ocean.font.fontSizeXxs)
+        }
+
+        // isInverted (novo): troca cor E fonte entre title/description.
+        // type == .inverted (legacy): continua trocando somente cores, sem mexer em fonte.
+
+        private func getTitleColor() -> UIColor {
+            if parameters.isInverted {
+                return descriptionColorForType()
+            }
+            return titleColorForType()
+        }
+
+        private func getDescriptionColor() -> UIColor {
+            if parameters.isInverted {
+                return titleColorForType()
+            }
+            return descriptionColorForType()
+        }
+
+        private func getTitleFont() -> UIFont? {
+            parameters.isInverted ? descriptionFontForType() : nil
+        }
+
+        private func getDescriptionFont() -> UIFont? {
+            parameters.isInverted ? titleFontForType() : descriptionFontForType()
         }
     }
 }

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -25,7 +25,7 @@ extension OceanSwiftUI {
         @Published public var tagStatus: TagParameters.Status
         @Published public var errorMessage: String
         @Published public var type: ContentListItemType
-        @Published public var inverted: Bool
+        @Published public var isInverted: Bool
         @Published public var showSkeleton: Bool
         @Published public var padding: EdgeInsets
 
@@ -40,7 +40,7 @@ extension OceanSwiftUI {
                     tagStatus: TagParameters.Status = .warning,
                     errorMessage: String = "",
                     type: ContentListItemType = .default,
-                    inverted: Bool = false,
+                    isInverted: Bool = false,
                     showSkeleton: Bool = false,
                     padding: EdgeInsets = .all(Ocean.size.spacingStackXs)) {
             self.title = title
@@ -54,7 +54,7 @@ extension OceanSwiftUI {
             self.tagStatus = tagStatus
             self.errorMessage = errorMessage
             self.type = type
-            self.inverted = inverted
+            self.isInverted = isInverted
             self.showSkeleton = showSkeleton
             self.padding = padding
         }
@@ -175,8 +175,12 @@ extension OceanSwiftUI {
         
         // MARK: Private Methods
         
+        private var resolvedInverted: Bool {
+            parameters.isInverted || parameters.type == .inverted
+        }
+
         private func getTitleColor() -> UIColor {
-            if parameters.inverted {
+            if resolvedInverted {
                 return Ocean.color.colorInterfaceDarkDown
             }
 
@@ -193,8 +197,13 @@ extension OceanSwiftUI {
                 return descriptionColor
             }
 
-            if parameters.inverted {
-                return Ocean.color.colorInterfaceDarkDeep
+            if resolvedInverted {
+                switch parameters.type {
+                case .highlight, .highlightLead:
+                    return Ocean.color.colorInterfaceDarkDeep
+                default:
+                    return Ocean.color.colorInterfaceDarkPure
+                }
             }
 
             switch parameters.type {

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -25,9 +25,10 @@ extension OceanSwiftUI {
         @Published public var tagStatus: TagParameters.Status
         @Published public var errorMessage: String
         @Published public var type: ContentListItemType
+        @Published public var inverted: Bool
         @Published public var showSkeleton: Bool
         @Published public var padding: EdgeInsets
-        
+
         public init(title: String = "",
                     description: String = "",
                     descriptionColor: UIColor? = nil,
@@ -39,6 +40,7 @@ extension OceanSwiftUI {
                     tagStatus: TagParameters.Status = .warning,
                     errorMessage: String = "",
                     type: ContentListItemType = .default,
+                    inverted: Bool = false,
                     showSkeleton: Bool = false,
                     padding: EdgeInsets = .all(Ocean.size.spacingStackXs)) {
             self.title = title
@@ -52,15 +54,17 @@ extension OceanSwiftUI {
             self.tagStatus = tagStatus
             self.errorMessage = errorMessage
             self.type = type
+            self.inverted = inverted
             self.showSkeleton = showSkeleton
             self.padding = padding
         }
-        
+
         public enum ContentListItemType {
             case `default`
             case inverted
             case inactive
             case highlight
+            case highlightLead
         }
     }
     
@@ -172,19 +176,27 @@ extension OceanSwiftUI {
         // MARK: Private Methods
         
         private func getTitleColor() -> UIColor {
+            if parameters.inverted {
+                return Ocean.color.colorInterfaceDarkDown
+            }
+
             switch parameters.type {
             case .default:
                 return Ocean.color.colorInterfaceDarkPure
-            case .inverted, .inactive, .highlight:
+            case .inverted, .inactive, .highlight, .highlightLead:
                 return Ocean.color.colorInterfaceDarkDown
             }
         }
-        
+
         private func getDescriptionColor() -> UIColor {
             if let descriptionColor = parameters.descriptionColor {
                 return descriptionColor
             }
-            
+
+            if parameters.inverted {
+                return Ocean.color.colorInterfaceDarkDeep
+            }
+
             switch parameters.type {
             case .default:
                 return Ocean.color.colorInterfaceDarkDown
@@ -192,17 +204,19 @@ extension OceanSwiftUI {
                 return Ocean.color.colorInterfaceDarkPure
             case .inactive:
                 return Ocean.color.colorInterfaceDarkUp
-            case .highlight:
+            case .highlight, .highlightLead:
                 return Ocean.color.colorInterfaceDarkDeep
             }
         }
-        
+
         private func getFont() -> UIFont? {
             if let font = parameters.descriptionFont { return font }
-            
+
             switch parameters.type {
             case .highlight:
                 return .baseBold(size: Ocean.font.fontSizeXs)
+            case .highlightLead:
+                return .baseBold(size: Ocean.font.fontSizeMd)
             default:
                 return .baseRegular(size: Ocean.font.fontSizeXs)
             }

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -198,15 +198,6 @@ extension OceanSwiftUI {
                 return descriptionColor
             }
 
-            if resolvedInverted {
-                switch parameters.type {
-                case .highlight, .highlightLead:
-                    return Ocean.color.colorInterfaceDarkDeep
-                default:
-                    return Ocean.color.colorInterfaceDarkPure
-                }
-            }
-
             switch parameters.type {
             case .default:
                 return Ocean.color.colorInterfaceDarkDown

--- a/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/ContentList/OceanSwiftUI+ContentList.swift
@@ -61,6 +61,7 @@ extension OceanSwiftUI {
 
         public enum ContentListItemType {
             case `default`
+            @available(*, deprecated, message: "Use isInverted = true no ContentListParameters. Este case sera removido em versao futura.")
             case inverted
             case inactive
             case highlight

--- a/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
@@ -1,0 +1,135 @@
+//
+//  OceanSwiftUI+TextListReadOnly.swift
+//  OceanComponents
+//
+//  Created by Acassio Mendonça on 20/04/26.
+//
+
+import OceanTokens
+import SwiftUI
+
+extension OceanSwiftUI {
+
+    // MARK: Parameter
+
+    public class TextListReadOnlyParameters: ObservableObject {
+        @Published public var state: State
+        @Published public var showIcon: Bool
+        @Published public var icon: UIImage?
+        @Published public var iconColor: UIColor
+        @Published public var iconSize: CGFloat
+        @Published public var showIndicator: Bool
+        @Published public var indicator: TagParameters?
+        @Published public var showDivider: Bool
+        @Published public var contentList: ContentListParameters
+        @Published public var backgroundColor: UIColor
+        @Published public var padding: EdgeInsets
+
+        public init(state: State = .default,
+                    showIcon: Bool = false,
+                    icon: UIImage? = nil,
+                    iconColor: UIColor = Ocean.color.colorInterfaceDarkDown,
+                    iconSize: CGFloat = 20,
+                    showIndicator: Bool = false,
+                    indicator: TagParameters? = nil,
+                    showDivider: Bool = false,
+                    contentList: ContentListParameters = ContentListParameters(),
+                    backgroundColor: UIColor = Ocean.color.colorInterfaceLightPure,
+                    padding: EdgeInsets = .all(Ocean.size.spacingStackXs)) {
+            self.state = state
+            self.showIcon = showIcon
+            self.icon = icon
+            self.iconColor = iconColor
+            self.iconSize = iconSize
+            self.showIndicator = showIndicator
+            self.indicator = indicator
+            self.showDivider = showDivider
+            self.contentList = contentList
+            self.backgroundColor = backgroundColor
+            self.padding = padding
+        }
+
+        public enum State {
+            case `default`
+            case disabled
+            case loading
+        }
+    }
+
+    public struct TextListReadOnly: View {
+
+        // MARK: Properties for UIKit
+
+        public lazy var hostingController = UIHostingController(rootView: self)
+        public lazy var uiView = hostingController.getUIView()
+
+        // MARK: Builder
+
+        public typealias Builder = (TextListReadOnly) -> Void
+
+        // MARK: Properties
+
+        @ObservedObject public var parameters: TextListReadOnlyParameters
+
+        // MARK: Constructors
+
+        public init(parameters: TextListReadOnlyParameters = TextListReadOnlyParameters()) {
+            self.parameters = parameters
+        }
+
+        public init(builder: Builder) {
+            self.init()
+            builder(self)
+        }
+
+        // MARK: View SwiftUI
+
+        public var body: some View {
+            VStack(spacing: 0) {
+                HStack(alignment: .center, spacing: Ocean.size.spacingStackXxs) {
+                    if parameters.showIcon, let icon = parameters.icon {
+                        Image(uiImage: icon)
+                            .resizable()
+                            .renderingMode(.template)
+                            .frame(width: parameters.iconSize,
+                                   height: parameters.iconSize)
+                            .foregroundColor(Color(parameters.iconColor))
+                    }
+
+                    ContentList(parameters: resolvedContentListParameters())
+
+                    if parameters.showIndicator, let tag = parameters.indicator {
+                        Tag(parameters: tag)
+                    }
+                }
+                .padding(parameters.padding)
+
+                if parameters.showDivider {
+                    Divider()
+                }
+            }
+            .background(Color(parameters.backgroundColor))
+        }
+
+        // MARK: Private Methods
+
+        private func resolvedContentListParameters() -> ContentListParameters {
+            let source = parameters.contentList
+            return ContentListParameters(
+                title: source.title,
+                description: source.description,
+                descriptionColor: source.descriptionColor,
+                descriptionFont: source.descriptionFont,
+                newDescription: source.newDescription,
+                caption: source.caption,
+                captionColor: source.captionColor,
+                tagTitle: source.tagTitle,
+                tagStatus: source.tagStatus,
+                errorMessage: source.errorMessage,
+                type: parameters.state == .disabled ? .inactive : source.type,
+                showSkeleton: parameters.state == .loading || source.showSkeleton,
+                padding: .all(0)
+            )
+        }
+    }
+}

--- a/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
@@ -122,7 +122,7 @@ extension OceanSwiftUI {
                 tagStatus: source.tagStatus,
                 errorMessage: source.errorMessage,
                 type: parameters.state == .disabled ? .inactive : source.type,
-                inverted: source.inverted,
+                isInverted: source.isInverted,
                 showSkeleton: parameters.state == .loading || source.showSkeleton,
                 padding: .all(0)
             )

--- a/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
@@ -122,6 +122,7 @@ extension OceanSwiftUI {
                 tagStatus: source.tagStatus,
                 errorMessage: source.errorMessage,
                 type: parameters.state == .disabled ? .inactive : source.type,
+                inverted: source.inverted,
                 showSkeleton: parameters.state == .loading || source.showSkeleton,
                 padding: .all(0)
             )

--- a/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift
@@ -17,9 +17,7 @@ extension OceanSwiftUI {
         @Published public var showIcon: Bool
         @Published public var icon: UIImage?
         @Published public var iconColor: UIColor
-        @Published public var iconSize: CGFloat
-        @Published public var showIndicator: Bool
-        @Published public var indicator: TagParameters?
+        @Published public var tag: TagParameters?
         @Published public var showDivider: Bool
         @Published public var contentList: ContentListParameters
         @Published public var backgroundColor: UIColor
@@ -29,9 +27,7 @@ extension OceanSwiftUI {
                     showIcon: Bool = false,
                     icon: UIImage? = nil,
                     iconColor: UIColor = Ocean.color.colorInterfaceDarkDown,
-                    iconSize: CGFloat = 20,
-                    showIndicator: Bool = false,
-                    indicator: TagParameters? = nil,
+                    tag: TagParameters? = nil,
                     showDivider: Bool = false,
                     contentList: ContentListParameters = ContentListParameters(),
                     backgroundColor: UIColor = Ocean.color.colorInterfaceLightPure,
@@ -40,9 +36,7 @@ extension OceanSwiftUI {
             self.showIcon = showIcon
             self.icon = icon
             self.iconColor = iconColor
-            self.iconSize = iconSize
-            self.showIndicator = showIndicator
-            self.indicator = indicator
+            self.tag = tag
             self.showDivider = showDivider
             self.contentList = contentList
             self.backgroundColor = backgroundColor
@@ -86,19 +80,20 @@ extension OceanSwiftUI {
 
         public var body: some View {
             VStack(spacing: 0) {
-                HStack(alignment: .center, spacing: Ocean.size.spacingStackXxs) {
+                HStack(alignment: .center, spacing: Ocean.size.spacingStackXxsExtra) {
                     if parameters.showIcon, let icon = parameters.icon {
                         Image(uiImage: icon)
                             .resizable()
                             .renderingMode(.template)
-                            .frame(width: parameters.iconSize,
-                                   height: parameters.iconSize)
                             .foregroundColor(Color(parameters.iconColor))
+                            .frame(width: Ocean.size.spacingStackXs,
+                                   height: Ocean.size.spacingStackXs)
+                            .padding(Ocean.size.spacingInsetXxs)
                     }
 
                     ContentList(parameters: resolvedContentListParameters())
 
-                    if parameters.showIndicator, let tag = parameters.indicator {
+                    if let tag = parameters.tag, !tag.label.isEmpty {
                         Tag(parameters: tag)
                     }
                 }

--- a/Sources/OceanComponents/Extensions Token/String+ContentListItemTypeExtensions.swift
+++ b/Sources/OceanComponents/Extensions Token/String+ContentListItemTypeExtensions.swift
@@ -15,6 +15,7 @@ public extension String {
         case "inverted": return OceanSwiftUI.ContentListParameters.ContentListItemType.inverted
         case "inactive": return OceanSwiftUI.ContentListParameters.ContentListItemType.inactive
         case "highlight": return OceanSwiftUI.ContentListParameters.ContentListItemType.highlight
+        case "highlightLead": return OceanSwiftUI.ContentListParameters.ContentListItemType.highlightLead
         case "default": return OceanSwiftUI.ContentListParameters.ContentListItemType.default
         default: return nil
         }


### PR DESCRIPTION
## Objetivo
Criar componente composto `OceanSwiftUI.TextListReadOnly` como pré-requisito do novo header da tela de Extrato (RF-08 iOS).

## RFs cobertos
RF-08 (pré) · PR #1 no plano de execução da issue-mãe

## Issue
Pagnet/pagnet#16085

## Escopo
- `Sources/OceanComponents/ComponentsSwiftUI/TextListReadOnly/OceanSwiftUI+TextListReadOnly.swift` — novo componente composto internamente por `ContentList` + slot opcional de ícone + `Tag` como indicador + `Divider` opcional.
- API pública espelha o Playground do Figma:
  - `state: .default | .disabled | .loading` (loading → `ContentList.showSkeleton=true`; disabled → força `type=.inactive`)
  - `showIcon`, `icon`, `iconColor`, `iconSize`
  - `showIndicator`, `indicator` (`TagParameters`)
  - `showDivider`
  - `contentList: ContentListParameters` repassando `type`, `title`, `description`, `caption`, etc.
  - `backgroundColor`, `padding`
- Demo controller `TextListReadOnlySwiftUIViewController` com 6 variantes cobrindo os cenários do Playground (inverted default, inverted + indicator, inverted + ícone + divider, default com caption, disabled, loading).
- Registro no catálogo: `DSComponents.listSwiftUI`, `DesignSystemComponentsSwiftUIType`, switch do `ComponentsSwiftUIViewController`.

## Notas de implementação
- Tokens Ocean em todos os valores (`spacingStackXxs`, `colorInterfaceLightPure`, etc.).
- O `ContentList` interno recebe `padding: .all(0)` porque o wrapper gerencia o padding externo.
- Quando `state == .loading`, o `showSkeleton` é aplicado no `ContentList` interno — reaproveita o `Skeleton` já existente lá.
- Não adiciona dependências nem altera `Package.swift`.

## Test plan
- [ ] Rodar `xcodebuild -scheme OceanComponents -destination 'generic/platform=iOS Simulator' build` (OK localmente)
- [ ] Rodar `xcodebuild -scheme OceanDesignSystem -destination 'generic/platform=iOS Simulator' build` (OK localmente)
- [ ] Abrir o app demo → seção **SwiftUI Components** → `TextListReadOnly` e inspecionar as 6 variantes
- [ ] Validar em preview (Xcode `PreviewProvider`) que as variantes batem com o Figma `22166:98221`
- [ ] Confirmar com design (D7) se o `backgroundColor` default (`colorInterfaceLightPure`) está correto ou se deve ser transparente


<img width="523" height="1003" alt="image" src="https://github.com/user-attachments/assets/72c60c99-65c8-46f6-8610-8379dc7be1cb" />
