### PR TITLE
fix(transaction-list-item): align label spacing with Android (BAN-57)

### DIFF
--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionListItem/OceanSwiftUI+TransactionListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionListItem/OceanSwiftUI+TransactionListItem.swift
@@ -331,7 +331,7 @@ extension OceanSwiftUI {
                     }
 
                     Spacer()
-                        .frame(height: Ocean.size.spacingStackXxs)
+                        .frame(height: Ocean.size.spacingStackXxxs)
                 }
 
                 if !parameters.level1.isEmpty {
@@ -358,7 +358,7 @@ extension OceanSwiftUI {
 
                 if !parameters.level3.isEmpty {
                     Spacer()
-                        .frame(height: Ocean.size.spacingStackXxs)
+                        .frame(height: Ocean.size.spacingStackXxxs)
 
                     OceanSwiftUI.Typography { label in
                         label.parameters.style = parameters.level3Style


### PR DESCRIPTION
## Summary
- Troca os tokens de espacamento vertical entre labels do `OceanSwiftUI.TransactionListItem` para alinhar com o padrao revisado no BAN-57 (RF-16) e com o que ja foi mergeado no Android em ocean-ds/ocean-android#1079.
- `highlighted -> title`: `spacingStackXxs` (8dp) -> `spacingStackXxxs` (4dp).
- `title -> description`: mantido em `0dp`.
- `description -> caption`: `spacingStackXxs` (8dp) -> `spacingStackXxxs` (4dp).

Sem mudanca de API publica. Decisao de manter os gaps fixos (nao parametrizados pelo consumer) segue a mesma escolha do Android.

## Issue
Closes #683
Refs Pagnet/pagnet#16085 (BAN-57 / RF-16)

## Como reproduzir o estado atual (antes do fix)
1. Rodar o app `OceanDesignSystem` no Xcode.
2. Abrir a tela `TransactionListItem (SwiftUI)`.
3. Observar gap de 8dp entre highlighted/title e entre description/caption — design pede 4dp.

## Como validar (depois do fix)
1. Rodar o mesmo sample app.
2. Conferir que os gaps sao agora 4dp / 0 / 4dp nos cenarios:
   - todos os 4 niveis (highlighted + title + description + caption);
   - apenas title + description;
   - title + description + caption (sem highlighted).
3. Comparar lado a lado com a PR Android #1079 e o Figma do BAN-57.

## Test plan
- [ ] Sample `TransactionListItemSwiftUIViewController` renderiza com gaps 4dp / 0 / 4dp nos 3 cenarios acima.
- [ ] Comparacao visual lado a lado com Android (PR #1079) e Figma do BAN-57.
- [ ] Consumer real `blu-mobile-ios` `ExtractViewController` continua compilando e visualmente OK.
- [ ] CI verde.

## Fora de escopo
- UIKit (`Ocean+TransactionListItem.swift`) nao foi tocado — usa um mix proprio de tokens em variantes diferentes; precisa de alinhamento separado se design pedir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)