### PR TITLE
feat(card-group): hide header when all header fields are empty

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16'
+          xcode-version: '26.1'
 
       - name: Set git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/head
-
+      
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16'
+          xcode-version: '26.1'
 
       - name: Set git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-26
+    runs-on: macos-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: latest-stable
 
       - name: Set git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -13,7 +13,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
           ref: refs/pull/${{ github.event.pull_request.number }}/head
-      
+
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1.2'
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '16'
 
       - name: Set git identity
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-26
+    runs-on: macos-15
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '16'
 
       - name: Set git identity
         run: |

--- a/OceanDesignSystem/Controllers/Components SwiftUI/CardGroupSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/CardGroupSwiftUIViewController.swift
@@ -290,6 +290,16 @@ class CardGroupSwiftUIViewController: UIViewController {
         }
     }
 
+    lazy var cardGroupWithoutHeader = OceanSwiftUI.CardGroup { view in
+        view.parameters.hasDivider = false
+        view.parameters.view = HStack {
+            OceanSwiftUI.TextListItem { view in
+                view.parameters.title = "Sem Header"
+                view.parameters.description = "Conteúdo vai ao topo"
+            }
+        }
+    }
+
     // MARK: - Hosting
     public lazy var hostingController = UIHostingController(rootView: ScrollView {
         VStack(spacing: Ocean.size.spacingStackXs) {
@@ -315,6 +325,7 @@ class CardGroupSwiftUIViewController: UIViewController {
             cardGroupWithAlertInfoWithoutImage
             cardGroupAlertInfoWithIconAndBadge
             cardGroupAlertInfoWithIconWhitoutBadge
+            cardGroupWithoutHeader
         }
     })
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
@@ -138,6 +138,51 @@ extension OceanSwiftUI {
             (parameters.tagLabelHeader != nil && !(parameters.tagLabelHeader?.isEmpty ?? true)) ||
             parameters.badgeCount != nil
         }
+        
+        @ViewBuilder
+        private var headerView: some View {
+            if hasHeaderContent {
+                HStack(alignment: .center, spacing: Ocean.size.spacingStackXs) {
+                    if let icon = self.parameters.icon {
+                        Image(uiImage: icon)
+                            .resizable()
+                            .frame(width: 24, height: 24, alignment: .center)
+                            .foregroundColor(Color(Ocean.color.colorInterfaceDarkDeep))
+                    }
+                    VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
+                        titleSubtitleCaptionView
+                        
+                        if let tagLabel = self.parameters.tagLabel {
+                            Tag { tag in
+                                tag.parameters.label = tagLabel
+                                tag.parameters.status = self.parameters.tagStatus
+                                tag.parameters.hasLabelBold = self.parameters.hasTagLabelBold
+                            }
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    if let tagLabelHeader = parameters.tagLabelHeader, !tagLabelHeader.isEmpty {
+                        Tag { tag in
+                            tag.parameters.label = tagLabelHeader
+                            tag.parameters.status = parameters.tagStatusHeader
+                            tag.parameters.hasLabelBold = parameters.hasTagLabelBold
+                        }
+                    } else if let badgeCount = parameters.badgeCount {
+                        Badge { badge in
+                            badge.parameters.count = badgeCount
+                            badge.parameters.status = self.parameters.badgeStatus
+                        }
+                    }
+                }
+                .frame(minWidth: 0, maxWidth: .infinity)
+                .padding(Ocean.size.spacingStackXs)
+                .background(Color(parameters.headerBackgroundColor ?? Ocean.color.colorInterfaceLightPure))
+            } else {
+                EmptyView()
+            }
+        }
 
         @ViewBuilder
         private var titleSubtitleCaptionView: some View {
@@ -209,45 +254,7 @@ extension OceanSwiftUI {
                 VStack(alignment: .leading, spacing: 0) {
                     ZStack(alignment: .topLeading) {
                         VStack(alignment: .leading, spacing: 0) {
-                            if hasHeaderContent {
-                                HStack(alignment: .center, spacing: Ocean.size.spacingStackXs) {
-                                    if let icon = self.parameters.icon {
-                                        Image(uiImage: icon)
-                                            .resizable()
-                                            .frame(width: 24, height: 24, alignment: .center)
-                                            .foregroundColor(Color(Ocean.color.colorInterfaceDarkDeep))
-                                    }
-                                    VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
-                                        titleSubtitleCaptionView
-
-                                        if let tagLabel = self.parameters.tagLabel {
-                                            Tag { tag in
-                                                tag.parameters.label = tagLabel
-                                                tag.parameters.status = self.parameters.tagStatus
-                                                tag.parameters.hasLabelBold = self.parameters.hasTagLabelBold
-                                            }
-                                        }
-                                    }
-
-                                    Spacer()
-
-                                    if let tagLabelHeader = parameters.tagLabelHeader, !tagLabelHeader.isEmpty {
-                                        Tag { tag in
-                                            tag.parameters.label = tagLabelHeader
-                                            tag.parameters.status = parameters.tagStatusHeader
-                                            tag.parameters.hasLabelBold = parameters.hasTagLabelBold
-                                        }
-                                    } else if let badgeCount = parameters.badgeCount {
-                                        Badge { badge in
-                                            badge.parameters.count = badgeCount
-                                            badge.parameters.status = self.parameters.badgeStatus
-                                        }
-                                    }
-                                }
-                                .frame(minWidth: 0, maxWidth: .infinity)
-                                .padding(Ocean.size.spacingStackXs)
-                                .background(Color(parameters.headerBackgroundColor ?? Ocean.color.colorInterfaceLightPure))
-                            }
+                            headerView
 
                             if let alert = parameters.alert {
                                 Alert.init(parameters: alert)

--- a/Sources/OceanComponents/ComponentsSwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/CardGroup/OceanSwiftUI+CardGroup.swift
@@ -129,6 +129,16 @@ extension OceanSwiftUI {
 
         // MARK: Properties private
 
+        private var hasHeaderContent: Bool {
+            !parameters.title.isEmpty ||
+            !parameters.subtitle.isEmpty ||
+            !parameters.caption.isEmpty ||
+            parameters.icon != nil ||
+            parameters.tagLabel != nil ||
+            (parameters.tagLabelHeader != nil && !(parameters.tagLabelHeader?.isEmpty ?? true)) ||
+            parameters.badgeCount != nil
+        }
+
         @ViewBuilder
         private var titleSubtitleCaptionView: some View {
             VStack(alignment: .leading, spacing: Ocean.size.spacingStackXxxs) {
@@ -199,43 +209,45 @@ extension OceanSwiftUI {
                 VStack(alignment: .leading, spacing: 0) {
                     ZStack(alignment: .topLeading) {
                         VStack(alignment: .leading, spacing: 0) {
-                            HStack(alignment: .center, spacing: Ocean.size.spacingStackXs) {
-                                if let icon = self.parameters.icon {
-                                    Image(uiImage: icon)
-                                        .resizable()
-                                        .frame(width: 24, height: 24, alignment: .center)
-                                        .foregroundColor(Color(Ocean.color.colorInterfaceDarkDeep))
-                                }
-                                VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
-                                    titleSubtitleCaptionView
+                            if hasHeaderContent {
+                                HStack(alignment: .center, spacing: Ocean.size.spacingStackXs) {
+                                    if let icon = self.parameters.icon {
+                                        Image(uiImage: icon)
+                                            .resizable()
+                                            .frame(width: 24, height: 24, alignment: .center)
+                                            .foregroundColor(Color(Ocean.color.colorInterfaceDarkDeep))
+                                    }
+                                    VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
+                                        titleSubtitleCaptionView
 
-                                    if let tagLabel = self.parameters.tagLabel {
+                                        if let tagLabel = self.parameters.tagLabel {
+                                            Tag { tag in
+                                                tag.parameters.label = tagLabel
+                                                tag.parameters.status = self.parameters.tagStatus
+                                                tag.parameters.hasLabelBold = self.parameters.hasTagLabelBold
+                                            }
+                                        }
+                                    }
+
+                                    Spacer()
+
+                                    if let tagLabelHeader = parameters.tagLabelHeader, !tagLabelHeader.isEmpty {
                                         Tag { tag in
-                                            tag.parameters.label = tagLabel
-                                            tag.parameters.status = self.parameters.tagStatus
-                                            tag.parameters.hasLabelBold = self.parameters.hasTagLabelBold
+                                            tag.parameters.label = tagLabelHeader
+                                            tag.parameters.status = parameters.tagStatusHeader
+                                            tag.parameters.hasLabelBold = parameters.hasTagLabelBold
+                                        }
+                                    } else if let badgeCount = parameters.badgeCount {
+                                        Badge { badge in
+                                            badge.parameters.count = badgeCount
+                                            badge.parameters.status = self.parameters.badgeStatus
                                         }
                                     }
                                 }
-
-                                Spacer()
-
-                                if let tagLabelHeader = parameters.tagLabelHeader, !tagLabelHeader.isEmpty {
-                                    Tag { tag in
-                                        tag.parameters.label = tagLabelHeader
-                                        tag.parameters.status = parameters.tagStatusHeader
-                                        tag.parameters.hasLabelBold = parameters.hasTagLabelBold
-                                    }
-                                } else if let badgeCount = parameters.badgeCount {
-                                    Badge { badge in
-                                        badge.parameters.count = badgeCount
-                                        badge.parameters.status = self.parameters.badgeStatus
-                                    }
-                                }
+                                .frame(minWidth: 0, maxWidth: .infinity)
+                                .padding(Ocean.size.spacingStackXs)
+                                .background(Color(parameters.headerBackgroundColor ?? Ocean.color.colorInterfaceLightPure))
                             }
-                            .frame(minWidth: 0, maxWidth: .infinity)
-                            .padding(Ocean.size.spacingStackXs)
-                            .background(Color(parameters.headerBackgroundColor ?? Ocean.color.colorInterfaceLightPure))
 
                             if let alert = parameters.alert {
                                 Alert.init(parameters: alert)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,11 +31,8 @@ platform :ios do
   end
 
   desc "Build and Test App"
-  lane :build_test do
-    run_tests(
-      scheme: "OceanDesignSystem",
-      destination: "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro"
-    )
+  lane :build_test do 
+    run_tests(scheme: "OceanDesignSystem")
   end
 
   desc "Prepare new version on master"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,8 +31,8 @@ platform :ios do
   end
 
   desc "Build and Test App"
-  lane :build_test do 
-    run_tests(scheme: "OceanDesignSystem")
+  lane :build_test do
+    run_tests(scheme: "OceanDesignSystem", devices: ["iPhone 16"])
   end
 
   desc "Prepare new version on master"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,7 +32,10 @@ platform :ios do
 
   desc "Build and Test App"
   lane :build_test do
-    run_tests(scheme: "OceanDesignSystem", devices: ["iPhone 16"])
+    run_tests(
+      scheme: "OceanDesignSystem",
+      destination: "platform=iOS Simulator,OS=latest,name=iPhone 17 Pro"
+    )
   end
 
   desc "Prepare new version on master"


### PR DESCRIPTION
## Summary

- `OceanCardGroup` now accepts `title: String = ""` (already had default) — other header fields (`subtitle`, `caption`, `icon`, `tagLabel`, `tagLabelHeader`, `badgeCount`) were already optional
- When ALL header fields are empty/nil, the header `HStack` is not composed at all — `content()` fills directly to the top of the card
- Mirrors the behavior shipped in [ocean-android#1090](https://github.com/ocean-ds/ocean-android/pull/1090)

## Screenshot

<img width="49%" alt="Simulator Screenshot - iPhone 17 - 2026-05-22 at 17 18 32" src="https://github.com/user-attachments/assets/f9413a87-d5dd-40c9-9865-a01317cb9fde" />

## Test plan

- [ ] Preview `CardGroupSwiftUIViewController` shows the new "Sem Header" case with content at the top
- [ ] Existing preview cases (with title) are unchanged