### PR TITLE
feat: add Banner component

### DIFF
--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -112,7 +112,7 @@ class BannerSwiftUIViewController: UIViewController {
         }
     }()
 
-    public lazy var hostingController = UIHostingController(rootView: ScrollView {
+    public lazy var hostingController = UIHostingController(rootView: AnyView(ScrollView {
         VStack(spacing: Ocean.size.spacingStackXs) {
             bannerLargeDefault
             bannerLargeWarning
@@ -124,7 +124,7 @@ class BannerSwiftUIViewController: UIViewController {
             bannerSmallEmphasys
         }
         .padding(.all, Ocean.size.spacingStackXs)
-    })
+    }))
 
     public lazy var uiView = self.hostingController.getUIView()
 

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -21,8 +21,8 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Default"
             view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
             view.parameters.buttons = [
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Ação Primária") { },
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Ação Secundária") { }
+                OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
+                OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
             ]
         }
     }()
@@ -35,7 +35,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
             view.parameters.buttons = [
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Entendi") { }
+                OceanSwiftUI.ButtonParameters(text: "Entendi")
             ]
         }
     }()
@@ -48,8 +48,8 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Negative"
             view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
             view.parameters.buttons = [
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Tentar novamente") { },
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Cancelar") { }
+                OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
+                OceanSwiftUI.ButtonParameters(text: "Cancelar")
             ]
         }
     }()
@@ -62,7 +62,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Emphasys"
             view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
             view.parameters.buttons = [
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Saiba mais") { }
+                OceanSwiftUI.ButtonParameters(text: "Saiba mais")
             ]
         }
     }()
@@ -96,7 +96,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Small Negative"
             view.parameters.description = "Erro compacto."
             view.parameters.buttons = [
-                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Corrigir") { }
+                OceanSwiftUI.ButtonParameters(text: "Corrigir")
             ]
         }
     }()

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -1,0 +1,149 @@
+//
+//  BannerSwiftUIViewController.swift
+//  OceanDesignSystem
+//
+//  Created by Mateus Amarante on 09/06/26.
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import Foundation
+import OceanTokens
+import OceanComponents
+import SwiftUI
+
+class BannerSwiftUIViewController: UIViewController {
+
+    // Large - Default
+    lazy var bannerLargeDefault: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .large
+            view.parameters.bannerType = .default
+            view.parameters.title = "Banner Large Default"
+            view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
+            view.parameters.buttons = [
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Ação Primária") { },
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Ação Secundária") { }
+            ]
+        }
+    }()
+
+    // Large - Warning
+    lazy var bannerLargeWarning: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .large
+            view.parameters.bannerType = .warning
+            view.parameters.title = "Banner Large Warning"
+            view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
+            view.parameters.buttons = [
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Entendi") { }
+            ]
+        }
+    }()
+
+    // Large - Negative
+    lazy var bannerLargeNegative: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .large
+            view.parameters.bannerType = .negative
+            view.parameters.title = "Banner Large Negative"
+            view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
+            view.parameters.buttons = [
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Tentar novamente") { },
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Cancelar") { }
+            ]
+        }
+    }()
+
+    // Large - Emphasys
+    lazy var bannerLargeEmphasys: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .large
+            view.parameters.bannerType = .emphasys
+            view.parameters.title = "Banner Large Emphasys"
+            view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
+            view.parameters.buttons = [
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Saiba mais") { }
+            ]
+        }
+    }()
+
+    // Small - Default (sem descrição)
+    lazy var bannerSmallDefault: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .small
+            view.parameters.bannerType = .default
+            view.parameters.title = "Banner Small Default"
+            view.parameters.image = UIImage(systemName: "photo")
+        }
+    }()
+
+    // Small - Warning
+    lazy var bannerSmallWarning: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .small
+            view.parameters.bannerType = .warning
+            view.parameters.title = "Banner Small Warning"
+            view.parameters.description = "Aviso compacto."
+            view.parameters.image = UIImage(systemName: "exclamationmark.triangle")
+        }
+    }()
+
+    // Small - Negative
+    lazy var bannerSmallNegative: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .small
+            view.parameters.bannerType = .negative
+            view.parameters.title = "Banner Small Negative"
+            view.parameters.description = "Erro compacto."
+            view.parameters.buttons = [
+                OceanSwiftUI.BannerParameters.BannerButtonParameters(text: "Corrigir") { }
+            ]
+        }
+    }()
+
+    // Small - Emphasys
+    lazy var bannerSmallEmphasys: OceanSwiftUI.Banner = {
+        OceanSwiftUI.Banner { view in
+            view.parameters.size = .small
+            view.parameters.bannerType = .emphasys
+            view.parameters.title = "Banner Small Emphasys"
+            view.parameters.description = "Destaque compacto com imagem."
+            view.parameters.image = UIImage(systemName: "star.fill")
+        }
+    }()
+
+    public lazy var hostingController = UIHostingController(rootView: ScrollView {
+        VStack(spacing: Ocean.size.spacingStackXs) {
+            bannerLargeDefault
+            bannerLargeWarning
+            bannerLargeNegative
+            bannerLargeEmphasys
+            bannerSmallDefault
+            bannerSmallWarning
+            bannerSmallNegative
+            bannerSmallEmphasys
+        }
+        .padding(.all, Ocean.size.spacingStackXs)
+    })
+
+    public lazy var uiView = self.hostingController.getUIView()
+
+    public override func viewDidLoad() {
+        self.view.backgroundColor = .white
+
+        self.view.addSubview(uiView)
+
+        uiView.oceanConstraints
+            .fill(to: self.view)
+            .make()
+    }
+}
+
+@available(iOS 13.0, *)
+struct BannerSwiftUIViewController_Preview: PreviewProvider {
+    static var previews: some View {
+        UIViewControllerPreview {
+            BannerSwiftUIViewController()
+        }
+    }
+}

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -35,8 +35,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
             view.parameters.buttons = [
-                OceanSwiftUI.ButtonParameters(text: "Entendi"),
-                OceanSwiftUI.ButtonParameters(text: "Cancelar")
+                OceanSwiftUI.ButtonParameters(text: "Entendi")
             ]
         }
     }()

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -20,7 +20,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .default
             view.parameters.title = "Banner Large Default"
             view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
-            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
                 OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
@@ -35,7 +34,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .warning
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
-            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Entendi"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -50,7 +48,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .negative
             view.parameters.title = "Banner Large Negative"
             view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
-            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -65,7 +62,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .emphasys
             view.parameters.title = "Banner Large Emphasys"
             view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
-            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Saiba mais")
             ]

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -69,13 +69,17 @@ class BannerSwiftUIViewController: UIViewController {
         }
     }()
 
-    // Small - Default (sem descrição)
+    // Small - Default
     lazy var bannerSmallDefault: OceanSwiftUI.Banner = {
         OceanSwiftUI.Banner { view in
             view.parameters.size = .small
             view.parameters.bannerType = .default
             view.parameters.title = "Banner Small Default"
-            view.parameters.image = UIImage(systemName: "photo")
+            view.parameters.description = "Descrição do banner small com tipo default."
+            view.parameters.buttons = [
+                OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
+                OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
+            ]
         }
     }()
 
@@ -85,8 +89,11 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.size = .small
             view.parameters.bannerType = .warning
             view.parameters.title = "Banner Small Warning"
-            view.parameters.description = "Aviso compacto."
-            view.parameters.image = UIImage(systemName: "exclamationmark.triangle")
+            view.parameters.description = "Atenção! Este é um banner de aviso compacto."
+            view.parameters.buttons = [
+                OceanSwiftUI.ButtonParameters(text: "Entendi"),
+                OceanSwiftUI.ButtonParameters(text: "Cancelar")
+            ]
         }
     }()
 
@@ -96,9 +103,10 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.size = .small
             view.parameters.bannerType = .negative
             view.parameters.title = "Banner Small Negative"
-            view.parameters.description = "Erro compacto."
+            view.parameters.description = "Ocorreu um erro. Banner negativo compacto."
             view.parameters.buttons = [
-                OceanSwiftUI.ButtonParameters(text: "Corrigir")
+                OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
+                OceanSwiftUI.ButtonParameters(text: "Cancelar")
             ]
         }
     }()
@@ -109,8 +117,11 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.size = .small
             view.parameters.bannerType = .emphasys
             view.parameters.title = "Banner Small Emphasys"
-            view.parameters.description = "Destaque compacto com imagem."
-            view.parameters.image = UIImage(systemName: "star.fill")
+            view.parameters.description = "Destaque compacto com fundo brand."
+            view.parameters.buttons = [
+                OceanSwiftUI.ButtonParameters(text: "Saiba mais"),
+                OceanSwiftUI.ButtonParameters(text: "Fechar")
+            ]
         }
     }()
 

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -20,7 +20,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .default
             view.parameters.title = "Banner Large Default"
             view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
-            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
                 OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
@@ -35,7 +34,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .warning
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
-            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Entendi"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -50,7 +48,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .negative
             view.parameters.title = "Banner Large Negative"
             view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
-            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -65,7 +62,6 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .emphasys
             view.parameters.title = "Banner Large Emphasys"
             view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
-            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Saiba mais"),
                 OceanSwiftUI.ButtonParameters(text: "Fechar")

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -20,6 +20,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .default
             view.parameters.title = "Banner Large Default"
             view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
+            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
                 OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
@@ -34,6 +35,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .warning
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
+            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Entendi"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -48,6 +50,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .negative
             view.parameters.title = "Banner Large Negative"
             view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
+            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -62,8 +65,10 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .emphasys
             view.parameters.title = "Banner Large Emphasys"
             view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
+            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
-                OceanSwiftUI.ButtonParameters(text: "Saiba mais")
+                OceanSwiftUI.ButtonParameters(text: "Saiba mais"),
+                OceanSwiftUI.ButtonParameters(text: "Fechar")
             ]
         }
     }()

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -20,6 +20,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .default
             view.parameters.title = "Banner Large Default"
             view.parameters.description = "Descrição opcional do banner no tamanho large com tipo default."
+            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Ação Primária"),
                 OceanSwiftUI.ButtonParameters(text: "Ação Secundária")
@@ -34,6 +35,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .warning
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
+            view.parameters.image = UIImage(named: "banner1")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Entendi"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -48,6 +50,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .negative
             view.parameters.title = "Banner Large Negative"
             view.parameters.description = "Ocorreu um erro. Este é um banner do tipo negativo."
+            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Tentar novamente"),
                 OceanSwiftUI.ButtonParameters(text: "Cancelar")
@@ -62,6 +65,7 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.bannerType = .emphasys
             view.parameters.title = "Banner Large Emphasys"
             view.parameters.description = "Destaque máximo! Este é um banner do tipo emphasys com fundo brand."
+            view.parameters.image = UIImage(named: "banner2")
             view.parameters.buttons = [
                 OceanSwiftUI.ButtonParameters(text: "Saiba mais")
             ]

--- a/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift
@@ -35,7 +35,8 @@ class BannerSwiftUIViewController: UIViewController {
             view.parameters.title = "Banner Large Warning"
             view.parameters.description = "Atenção! Este é um banner de aviso com tipo warning."
             view.parameters.buttons = [
-                OceanSwiftUI.ButtonParameters(text: "Entendi")
+                OceanSwiftUI.ButtonParameters(text: "Entendi"),
+                OceanSwiftUI.ButtonParameters(text: "Cancelar")
             ]
         }
     }()

--- a/OceanDesignSystem/Controllers/Components SwiftUI/ComponentsSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/ComponentsSwiftUIViewController.swift
@@ -40,6 +40,8 @@ class ComponentsSwiftUIViewController: UITableViewController {
         tableView.deselectRow(at: indexPath, animated: true)
 
         switch self.designSystemComponentsTypeSelected! {
+        case .Banner:
+            self.present(BannerSwiftUIViewController(), animated: true, completion: nil)
         case .Alert:
             self.present(AlertSwiftUIViewController(), animated: true, completion: nil)
         case .Button:

--- a/OceanDesignSystem/Enums/Enums.swift
+++ b/OceanDesignSystem/Enums/Enums.swift
@@ -82,6 +82,7 @@ public enum DesignSystemComponentsSwiftUIType: String {
     case Alert
     case Badge
     case Balance
+    case Banner
     case Button
     case CardCrossSell
     case CardCTA

--- a/OceanDesignSystem/Models/Components.swift
+++ b/OceanDesignSystem/Models/Components.swift
@@ -67,6 +67,7 @@ struct DSComponents {
         "Alert",
         "Badge",
         "Balance",
+        "Banner",
         "Button",
         "CardCrossSell",
         "CardCTA",

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -97,35 +97,35 @@ extension OceanSwiftUI {
             VStack(alignment: .leading, spacing: 0) {
                 if hasImage {
                     bannerImage
-                        .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
                         .frame(maxWidth: .infinity)
+                        .frame(height: 190)
                         .clipped()
                 }
 
-                contentStack
+                contentView(textToButtonSpacing: Ocean.size.spacingStackSm)
                     .padding(.all, Ocean.size.spacingStackXs)
             }
             .frame(maxWidth: .infinity)
         }
 
         private var smallLayout: some View {
-            HStack(alignment: .top, spacing: Ocean.size.spacingStackXs) {
-                contentStack
+            HStack(alignment: .top, spacing: 0) {
+                contentView(textToButtonSpacing: Ocean.size.spacingStackXxsExtra)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.all, Ocean.size.spacingStackXs)
 
                 if hasImage {
                     bannerImage
-                        .frame(width: 82, height: 82)
+                        .frame(width: 82)
+                        .frame(maxHeight: .infinity)
                         .clipped()
-                        .cornerRadius(Ocean.size.borderRadiusSm)
                 }
             }
-            .padding(.all, Ocean.size.spacingStackXs)
             .frame(maxWidth: .infinity, alignment: .leading)
         }
 
-        private var contentStack: some View {
-            VStack(alignment: .leading, spacing: Ocean.size.spacingStackXxs) {
+        private func contentView(textToButtonSpacing: CGFloat) -> some View {
+            VStack(alignment: .leading, spacing: Ocean.size.spacingStackXxxs) {
                 if !parameters.title.isEmpty {
                     titleView
                 }
@@ -136,12 +136,13 @@ extension OceanSwiftUI {
 
                 if !parameters.buttons.isEmpty {
                     let limitedButtons = Array(parameters.buttons.prefix(2))
-                    VStack(spacing: Ocean.size.spacingStackXxs) {
+                    HStack(spacing: Ocean.size.spacingInlineXs) {
                         ForEach(Array(limitedButtons.enumerated()), id: \.offset) { index, buttonParam in
                             buttonView(for: buttonParam, isPrimary: index == 0)
+                                .fixedSize()
                         }
                     }
-                    .padding(.top, Ocean.size.spacingStackXxsExtra)
+                    .padding(.top, textToButtonSpacing)
                 }
             }
         }

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -151,13 +151,16 @@ extension OceanSwiftUI {
             Typography.heading4 { label in
                 label.parameters.text = self.parameters.title
                 label.parameters.textColor = self.resolvedTitleColor
+                label.parameters.lineSpacing = Ocean.font.lineHeightMedium
             }
         }
 
         private var descriptionView: some View {
-            Typography.paragraph { label in
+            Typography.description { label in
                 label.parameters.text = self.parameters.description
                 label.parameters.textColor = self.resolvedDescriptionColor
+                label.parameters.font = UIFont(name: Ocean.font.fontFamilyBaseWeightMedium,
+                                               size: Ocean.font.fontSizeXxs)
             }
         }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -1,0 +1,252 @@
+//
+//  OceanSwiftUI+Banner.swift
+//  OceanComponents
+//
+//  Created by Mateus Amarante on 09/06/26.
+//
+
+import SwiftUI
+import OceanTokens
+
+extension OceanSwiftUI {
+
+    // MARK: Parameters
+
+    public class BannerParameters: ObservableObject {
+
+        public enum Size {
+            case large
+            case small
+        }
+
+        public enum BannerType {
+            case `default`
+            case warning
+            case negative
+            case emphasys
+        }
+
+        public struct BannerButtonParameters {
+            public var text: String
+            public var onTouch: () -> Void
+
+            public init(text: String, onTouch: @escaping () -> Void = { }) {
+                self.text = text
+                self.onTouch = onTouch
+            }
+        }
+
+        @Published public var size: Size
+        @Published public var bannerType: BannerType
+        @Published public var title: String
+        @Published public var description: String
+        @Published public var image: UIImage?
+        @Published public var imageURL: String?
+        @Published public var backgroundColor: UIColor?
+        @Published public var buttons: [BannerButtonParameters]
+
+        public init(size: Size = .large,
+                    bannerType: BannerType = .default,
+                    title: String = "",
+                    description: String = "",
+                    image: UIImage? = nil,
+                    imageURL: String? = nil,
+                    backgroundColor: UIColor? = nil,
+                    buttons: [BannerButtonParameters] = []) {
+            self.size = size
+            self.bannerType = bannerType
+            self.title = title
+            self.description = description
+            self.image = image
+            self.imageURL = imageURL
+            self.backgroundColor = backgroundColor
+            self.buttons = buttons
+        }
+    }
+
+    public struct Banner: View {
+
+        // MARK: Properties for UIKit
+
+        public lazy var hostingController = UIHostingController(rootView: self)
+        public lazy var uiView = self.hostingController.getUIView()
+
+        // MARK: Builder
+
+        public typealias Builder = (Banner) -> Void
+
+        // MARK: Properties
+
+        @ObservedObject public var parameters: BannerParameters
+
+        // MARK: Private properties
+
+        @State private var downloadedImage: UIImage?
+
+        // MARK: Constructors
+
+        public init(parameters: BannerParameters = BannerParameters()) {
+            self.parameters = parameters
+        }
+
+        public init(builder: Builder) {
+            self.init()
+            builder(self)
+        }
+
+        // MARK: View SwiftUI
+
+        public var body: some View {
+            Group {
+                if parameters.size == .large {
+                    largeLayout
+                } else {
+                    smallLayout
+                }
+            }
+            .background(Color(resolvedBackgroundColor))
+            .cornerRadius(Ocean.size.borderRadiusMd)
+            .onAppear {
+                loadImageIfNeeded()
+            }
+        }
+
+        // MARK: Layouts
+
+        private var largeLayout: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                imageView
+                    .map { img in
+                        AnyView(
+                            img
+                                .resizable()
+                                .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
+                                .frame(maxWidth: .infinity)
+                                .clipped()
+                        )
+                    } ?? AnyView(EmptyView())
+
+                contentStack
+                    .padding(.all, Ocean.size.spacingStackXs)
+            }
+            .frame(maxWidth: .infinity)
+        }
+
+        private var smallLayout: some View {
+            HStack(alignment: .top, spacing: Ocean.size.spacingStackXs) {
+                contentStack
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                imageView
+                    .map { img in
+                        AnyView(
+                            img
+                                .resizable()
+                                .aspectRatio(contentMode: .fill)
+                                .frame(width: 80, height: 80)
+                                .clipped()
+                                .cornerRadius(Ocean.size.borderRadiusSm)
+                        )
+                    } ?? AnyView(EmptyView())
+            }
+            .padding(.all, Ocean.size.spacingStackXs)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        private var contentStack: some View {
+            VStack(alignment: .leading, spacing: Ocean.size.spacingStackXxs) {
+                if !parameters.title.isEmpty {
+                    Typography.heading4 { label in
+                        label.parameters.text = self.parameters.title
+                        label.parameters.textColor = self.resolvedTextColor
+                    }
+                }
+
+                if !parameters.description.isEmpty {
+                    Typography.paragraph { label in
+                        label.parameters.text = self.parameters.description
+                        label.parameters.textColor = self.resolvedTextColor
+                    }
+                }
+
+                if !parameters.buttons.isEmpty {
+                    let limitedButtons = Array(parameters.buttons.prefix(2))
+                    VStack(spacing: Ocean.size.spacingStackXxs) {
+                        ForEach(Array(limitedButtons.enumerated()), id: \.offset) { _, buttonParam in
+                            buttonView(for: buttonParam)
+                        }
+                    }
+                    .padding(.top, Ocean.size.spacingStackXxs)
+                }
+            }
+        }
+
+        @ViewBuilder
+        private func buttonView(for buttonParam: BannerParameters.BannerButtonParameters) -> some View {
+            if parameters.bannerType == .emphasys {
+                OceanSwiftUI.Button.primaryInverseMD { button in
+                    button.parameters.text = buttonParam.text
+                    button.parameters.onTouch = buttonParam.onTouch
+                }
+            } else {
+                OceanSwiftUI.Button.primarySM { button in
+                    button.parameters.text = buttonParam.text
+                    button.parameters.onTouch = buttonParam.onTouch
+                }
+            }
+        }
+
+        // MARK: Helpers
+
+        private var imageView: Image? {
+            if let img = parameters.image {
+                return Image(uiImage: img)
+            }
+            if let img = downloadedImage {
+                return Image(uiImage: img)
+            }
+            return nil
+        }
+
+        private var resolvedBackgroundColor: UIColor {
+            if let custom = parameters.backgroundColor {
+                return custom
+            }
+            switch parameters.bannerType {
+            case .default:
+                return Ocean.color.colorInterfaceLightUp
+            case .warning:
+                return Ocean.color.colorStatusWarningUp
+            case .negative:
+                return Ocean.color.colorStatusNegativeUp
+            case .emphasys:
+                return Ocean.color.colorBrandPrimaryPure
+            }
+        }
+
+        private var resolvedTextColor: UIColor {
+            switch parameters.bannerType {
+            case .emphasys:
+                return Ocean.color.colorInterfaceLightPure
+            default:
+                return Ocean.color.colorInterfaceDarkDeep
+            }
+        }
+
+        private func loadImageIfNeeded() {
+            guard parameters.image == nil,
+                  let urlString = parameters.imageURL,
+                  !urlString.isEmpty else { return }
+
+            urlString.getImage { result in
+                if let img = try? result.get(), let img = img {
+                    DispatchQueue.main.async {
+                        self.downloadedImage = img
+                    }
+                }
+            }
+        }
+
+        // MARK: Methods private
+    }
+}

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -239,7 +239,7 @@ extension OceanSwiftUI {
                   !urlString.isEmpty else { return }
 
             urlString.getImage { result in
-                if let img = try? result.get(), let img = img {
+                if let img = try? result.get() {
                     DispatchQueue.main.async {
                         self.downloadedImage = img
                     }

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -102,7 +102,7 @@ extension OceanSwiftUI {
                         .clipped()
                 }
 
-                contentView(textToButtonSpacing: Ocean.size.spacingStackSm)
+                contentView(textToButtonSpacing: Ocean.size.spacingStackSm - Ocean.size.spacingStackXxxs)
                     .padding(.all, Ocean.size.spacingStackXs)
             }
             .frame(maxWidth: .infinity)
@@ -110,7 +110,7 @@ extension OceanSwiftUI {
 
         private var smallLayout: some View {
             HStack(alignment: .top, spacing: 0) {
-                contentView(textToButtonSpacing: Ocean.size.spacingStackXxsExtra)
+                contentView(textToButtonSpacing: Ocean.size.spacingStackXxs)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.all, Ocean.size.spacingStackXs)
 
@@ -152,6 +152,8 @@ extension OceanSwiftUI {
                 label.parameters.text = self.parameters.title
                 label.parameters.textColor = self.resolvedTitleColor
                 label.parameters.lineSpacing = Ocean.font.lineHeightMedium
+                label.parameters.font = UIFont(name: Ocean.font.fontFamilyBaseWeightBold,
+                                               size: Ocean.font.fontSizeXs)
             }
         }
 
@@ -161,6 +163,7 @@ extension OceanSwiftUI {
                 label.parameters.textColor = self.resolvedDescriptionColor
                 label.parameters.font = UIFont(name: Ocean.font.fontFamilyBaseWeightMedium,
                                                size: Ocean.font.fontSizeXxs)
+                label.parameters.lineSpacing = Ocean.font.lineHeightComfy
             }
         }
 
@@ -207,10 +210,15 @@ extension OceanSwiftUI {
                         button.parameters.onTouch = buttonParam.onTouch
                     }
                 case .emphasys:
-                    OceanSwiftUI.Button.primaryInverseSM { button in
-                        button.parameters.text = buttonParam.text
-                        button.parameters.onTouch = buttonParam.onTouch
+                    // Tertiary com colorInterfaceLightPure — escopo exclusivo do Emphasys
+                    SwiftUI.Button(action: buttonParam.onTouch) {
+                        Text(buttonParam.text)
+                            .font(Font(UIFont.baseBold(size: Ocean.font.fontSizeXxs)!))
+                            .foregroundColor(Color(Ocean.color.colorInterfaceLightPure))
+                            .fixedSize(horizontal: true, vertical: false)
                     }
+                    .buttonStyle(.plain)
+                    .fixedSize()
                 }
             }
         }

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -88,7 +88,7 @@ extension OceanSwiftUI {
                 }
             }
             .background(Color(resolvedBackgroundColor))
-            .cornerRadius(Ocean.size.borderRadiusMd)
+            .cornerRadius(Ocean.size.borderRadiusSm)
         }
 
         // MARK: Layouts
@@ -115,7 +115,7 @@ extension OceanSwiftUI {
 
                 if hasImage {
                     bannerImage
-                        .frame(width: 80, height: 80)
+                        .frame(width: 82, height: 82)
                         .clipped()
                         .cornerRadius(Ocean.size.borderRadiusSm)
                 }
@@ -137,11 +137,11 @@ extension OceanSwiftUI {
                 if !parameters.buttons.isEmpty {
                     let limitedButtons = Array(parameters.buttons.prefix(2))
                     VStack(spacing: Ocean.size.spacingStackXxs) {
-                        ForEach(Array(limitedButtons.enumerated()), id: \.offset) { _, buttonParam in
-                            buttonView(for: buttonParam)
+                        ForEach(Array(limitedButtons.enumerated()), id: \.offset) { index, buttonParam in
+                            buttonView(for: buttonParam, isPrimary: index == 0)
                         }
                     }
-                    .padding(.top, Ocean.size.spacingStackXxs)
+                    .padding(.top, Ocean.size.spacingStackXxsExtra)
                 }
             }
         }
@@ -149,28 +149,64 @@ extension OceanSwiftUI {
         private var titleView: some View {
             Typography.heading4 { label in
                 label.parameters.text = self.parameters.title
-                label.parameters.textColor = self.resolvedTextColor
+                label.parameters.textColor = self.resolvedTitleColor
             }
         }
 
         private var descriptionView: some View {
             Typography.paragraph { label in
                 label.parameters.text = self.parameters.description
-                label.parameters.textColor = self.resolvedTextColor
+                label.parameters.textColor = self.resolvedDescriptionColor
             }
         }
 
         @ViewBuilder
-        private func buttonView(for buttonParam: ButtonParameters) -> some View {
-            if parameters.bannerType == .emphasys {
-                OceanSwiftUI.Button.primaryInverseMD { button in
-                    button.parameters.text = buttonParam.text
-                    button.parameters.onTouch = buttonParam.onTouch
+        private func buttonView(for buttonParam: ButtonParameters, isPrimary: Bool) -> some View {
+            if isPrimary {
+                switch parameters.bannerType {
+                case .default:
+                    OceanSwiftUI.Button.primarySM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .warning:
+                    OceanSwiftUI.Button.primaryWarningSM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .negative:
+                    OceanSwiftUI.Button.primaryCriticalSM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .emphasys:
+                    OceanSwiftUI.Button.secondarySM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
                 }
             } else {
-                OceanSwiftUI.Button.primarySM { button in
-                    button.parameters.text = buttonParam.text
-                    button.parameters.onTouch = buttonParam.onTouch
+                switch parameters.bannerType {
+                case .default:
+                    OceanSwiftUI.Button.tertiarySM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .warning:
+                    OceanSwiftUI.Button.tertiaryWarningSM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .negative:
+                    OceanSwiftUI.Button.tertiaryCriticalSM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
+                case .emphasys:
+                    OceanSwiftUI.Button.primaryInverseSM { button in
+                        button.parameters.text = buttonParam.text
+                        button.parameters.onTouch = buttonParam.onTouch
+                    }
                 }
             }
         }
@@ -205,12 +241,21 @@ extension OceanSwiftUI {
             }
         }
 
-        private var resolvedTextColor: UIColor {
+        private var resolvedTitleColor: UIColor {
             switch parameters.bannerType {
             case .emphasys:
                 return Ocean.color.colorInterfaceLightPure
             default:
                 return Ocean.color.colorInterfaceDarkDeep
+            }
+        }
+
+        private var resolvedDescriptionColor: UIColor {
+            switch parameters.bannerType {
+            case .emphasys:
+                return Ocean.color.colorInterfaceLightUp
+            default:
+                return Ocean.color.colorInterfaceDarkDown
             }
         }
     }

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -26,24 +26,13 @@ extension OceanSwiftUI {
             case emphasys
         }
 
-        public struct BannerButtonParameters {
-            public var text: String
-            public var onTouch: () -> Void
-
-            public init(text: String, onTouch: @escaping () -> Void = { }) {
-                self.text = text
-                self.onTouch = onTouch
-            }
-        }
-
         @Published public var size: Size
         @Published public var bannerType: BannerType
         @Published public var title: String
         @Published public var description: String
         @Published public var image: UIImage?
         @Published public var imageURL: String?
-        @Published public var backgroundColor: UIColor?
-        @Published public var buttons: [BannerButtonParameters]
+        @Published public var buttons: [ButtonParameters]
 
         public init(size: Size = .large,
                     bannerType: BannerType = .default,
@@ -51,15 +40,13 @@ extension OceanSwiftUI {
                     description: String = "",
                     image: UIImage? = nil,
                     imageURL: String? = nil,
-                    backgroundColor: UIColor? = nil,
-                    buttons: [BannerButtonParameters] = []) {
+                    buttons: [ButtonParameters] = []) {
             self.size = size
             self.bannerType = bannerType
             self.title = title
             self.description = description
             self.image = image
             self.imageURL = imageURL
-            self.backgroundColor = backgroundColor
             self.buttons = buttons
         }
     }
@@ -78,10 +65,6 @@ extension OceanSwiftUI {
         // MARK: Properties
 
         @ObservedObject public var parameters: BannerParameters
-
-        // MARK: Private properties
-
-        @State private var downloadedImage: UIImage?
 
         // MARK: Constructors
 
@@ -106,25 +89,18 @@ extension OceanSwiftUI {
             }
             .background(Color(resolvedBackgroundColor))
             .cornerRadius(Ocean.size.borderRadiusMd)
-            .onAppear {
-                loadImageIfNeeded()
-            }
         }
 
         // MARK: Layouts
 
         private var largeLayout: some View {
             VStack(alignment: .leading, spacing: 0) {
-                imageView
-                    .map { img in
-                        AnyView(
-                            img
-                                .resizable()
-                                .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
-                                .frame(maxWidth: .infinity)
-                                .clipped()
-                        )
-                    } ?? AnyView(EmptyView())
+                if hasImage {
+                    bannerImage
+                        .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
+                        .frame(maxWidth: .infinity)
+                        .clipped()
+                }
 
                 contentStack
                     .padding(.all, Ocean.size.spacingStackXs)
@@ -137,17 +113,12 @@ extension OceanSwiftUI {
                 contentStack
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                imageView
-                    .map { img in
-                        AnyView(
-                            img
-                                .resizable()
-                                .aspectRatio(contentMode: .fill)
-                                .frame(width: 80, height: 80)
-                                .clipped()
-                                .cornerRadius(Ocean.size.borderRadiusSm)
-                        )
-                    } ?? AnyView(EmptyView())
+                if hasImage {
+                    bannerImage
+                        .frame(width: 80, height: 80)
+                        .clipped()
+                        .cornerRadius(Ocean.size.borderRadiusSm)
+                }
             }
             .padding(.all, Ocean.size.spacingStackXs)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -156,17 +127,11 @@ extension OceanSwiftUI {
         private var contentStack: some View {
             VStack(alignment: .leading, spacing: Ocean.size.spacingStackXxs) {
                 if !parameters.title.isEmpty {
-                    Typography.heading4 { label in
-                        label.parameters.text = self.parameters.title
-                        label.parameters.textColor = self.resolvedTextColor
-                    }
+                    titleView
                 }
 
                 if !parameters.description.isEmpty {
-                    Typography.paragraph { label in
-                        label.parameters.text = self.parameters.description
-                        label.parameters.textColor = self.resolvedTextColor
-                    }
+                    descriptionView
                 }
 
                 if !parameters.buttons.isEmpty {
@@ -181,8 +146,22 @@ extension OceanSwiftUI {
             }
         }
 
+        private var titleView: some View {
+            Typography.heading4 { label in
+                label.parameters.text = self.parameters.title
+                label.parameters.textColor = self.resolvedTextColor
+            }
+        }
+
+        private var descriptionView: some View {
+            Typography.paragraph { label in
+                label.parameters.text = self.parameters.description
+                label.parameters.textColor = self.resolvedTextColor
+            }
+        }
+
         @ViewBuilder
-        private func buttonView(for buttonParam: BannerParameters.BannerButtonParameters) -> some View {
+        private func buttonView(for buttonParam: ButtonParameters) -> some View {
             if parameters.bannerType == .emphasys {
                 OceanSwiftUI.Button.primaryInverseMD { button in
                     button.parameters.text = buttonParam.text
@@ -196,22 +175,24 @@ extension OceanSwiftUI {
             }
         }
 
-        // MARK: Helpers
+        // MARK: Private properties
 
-        private var imageView: Image? {
-            if let img = parameters.image {
-                return Image(uiImage: img)
+        private var hasImage: Bool {
+            parameters.image != nil || !(parameters.imageURL?.isEmpty ?? true)
+        }
+
+        @ViewBuilder
+        private var bannerImage: some View {
+            if let image = parameters.image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else if let url = parameters.imageURL, !url.isEmpty {
+                OceanSwiftUI.ImageDownload(parameters: .init(url: url, contentMode: .fill))
             }
-            if let img = downloadedImage {
-                return Image(uiImage: img)
-            }
-            return nil
         }
 
         private var resolvedBackgroundColor: UIColor {
-            if let custom = parameters.backgroundColor {
-                return custom
-            }
             switch parameters.bannerType {
             case .default:
                 return Ocean.color.colorInterfaceLightUp
@@ -232,21 +213,5 @@ extension OceanSwiftUI {
                 return Ocean.color.colorInterfaceDarkDeep
             }
         }
-
-        private func loadImageIfNeeded() {
-            guard parameters.image == nil,
-                  let urlString = parameters.imageURL,
-                  !urlString.isEmpty else { return }
-
-            urlString.getImage { result in
-                if let img = try? result.get() {
-                    DispatchQueue.main.async {
-                        self.downloadedImage = img
-                    }
-                }
-            }
-        }
-
-        // MARK: Methods private
     }
 }

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -100,6 +100,8 @@ extension OceanSwiftUI {
                         .frame(maxWidth: .infinity)
                         .frame(height: 190)
                         .clipped()
+                } else {
+                    largeImagePlaceholder
                 }
 
                 contentView(textToButtonSpacing: Ocean.size.spacingStackSm - Ocean.size.spacingStackXxxs)
@@ -107,6 +109,24 @@ extension OceanSwiftUI {
                     .padding(.all, Ocean.size.spacingStackXs)
             }
             .frame(maxWidth: .infinity)
+        }
+
+        private var largeImagePlaceholder: some View {
+            ZStack {
+                Color(UIColor(red: 237/255, green: 234/255, blue: 255/255, alpha: 1))
+                Image(systemName: "photo")
+                    .font(.system(size: 32, weight: .regular))
+                    .foregroundColor(Color(UIColor(red: 123/255, green: 97/255, blue: 255/255, alpha: 1)))
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 190)
+            .overlay(
+                Rectangle()
+                    .strokeBorder(
+                        style: StrokeStyle(lineWidth: 1.5, dash: [8, 5])
+                    )
+                    .foregroundColor(Color(UIColor(red: 123/255, green: 97/255, blue: 255/255, alpha: 1)))
+            )
         }
 
         private var smallLayout: some View {

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -83,7 +83,6 @@ extension OceanSwiftUI {
             Group {
                 if parameters.size == .large {
                     largeLayout
-                        .aspectRatio(1, contentMode: .fit)
                 } else {
                     smallLayout
                 }
@@ -99,7 +98,7 @@ extension OceanSwiftUI {
                 if hasImage {
                     bannerImage
                         .frame(maxWidth: .infinity)
-                        .frame(maxHeight: .infinity)
+                        .frame(height: 190)
                         .clipped()
                 }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -83,6 +83,7 @@ extension OceanSwiftUI {
             Group {
                 if parameters.size == .large {
                     largeLayout
+                        .aspectRatio(1, contentMode: .fit)
                 } else {
                     smallLayout
                 }
@@ -98,7 +99,7 @@ extension OceanSwiftUI {
                 if hasImage {
                     bannerImage
                         .frame(maxWidth: .infinity)
-                        .frame(height: 190)
+                        .frame(maxHeight: .infinity)
                         .clipped()
                 }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -103,6 +103,7 @@ extension OceanSwiftUI {
                 }
 
                 contentView(textToButtonSpacing: Ocean.size.spacingStackSm - Ocean.size.spacingStackXxxs)
+                    .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.all, Ocean.size.spacingStackXs)
             }
             .frame(maxWidth: .infinity)

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -140,9 +140,29 @@ extension OceanSwiftUI {
                         .frame(width: 82)
                         .frame(maxHeight: .infinity)
                         .clipped()
+                } else {
+                    smallImagePlaceholder
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+        }
+
+        private var smallImagePlaceholder: some View {
+            ZStack {
+                Color(UIColor(red: 237/255, green: 234/255, blue: 255/255, alpha: 1))
+                Image(systemName: "photo")
+                    .font(.system(size: 24, weight: .regular))
+                    .foregroundColor(Color(UIColor(red: 123/255, green: 97/255, blue: 255/255, alpha: 1)))
+            }
+            .frame(width: 82)
+            .frame(maxHeight: .infinity)
+            .overlay(
+                Rectangle()
+                    .strokeBorder(
+                        style: StrokeStyle(lineWidth: 1.5, dash: [8, 5])
+                    )
+                    .foregroundColor(Color(UIColor(red: 123/255, green: 97/255, blue: 255/255, alpha: 1)))
+            )
         }
 
         private func contentView(textToButtonSpacing: CGFloat) -> some View {

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -66,15 +66,6 @@ extension OceanSwiftUI {
 
         @ObservedObject public var parameters: BannerParameters
 
-        @State private var smallContentHeight: CGFloat = 0
-
-        private struct SmallContentHeightKey: PreferenceKey {
-            static var defaultValue: CGFloat = 0
-            static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
-                value = max(value, nextValue())
-            }
-        }
-
         // MARK: Constructors
 
         public init(parameters: BannerParameters = BannerParameters()) {
@@ -122,21 +113,15 @@ extension OceanSwiftUI {
                 contentView(textToButtonSpacing: Ocean.size.spacingStackXxs)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.all, Ocean.size.spacingStackXs)
-                    .background(
-                        GeometryReader { proxy in
-                            Color.clear.preference(key: SmallContentHeightKey.self,
-                                                   value: proxy.size.height)
-                        }
-                    )
 
                 if hasImage {
                     bannerImage
-                        .frame(width: 82, height: smallContentHeight)
+                        .frame(width: 82)
+                        .frame(maxHeight: .infinity)
                         .clipped()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .onPreferenceChange(SmallContentHeightKey.self) { smallContentHeight = $0 }
         }
 
         private func contentView(textToButtonSpacing: CGFloat) -> some View {

--- a/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Banner/OceanSwiftUI+Banner.swift
@@ -66,6 +66,15 @@ extension OceanSwiftUI {
 
         @ObservedObject public var parameters: BannerParameters
 
+        @State private var smallContentHeight: CGFloat = 0
+
+        private struct SmallContentHeightKey: PreferenceKey {
+            static var defaultValue: CGFloat = 0
+            static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+                value = max(value, nextValue())
+            }
+        }
+
         // MARK: Constructors
 
         public init(parameters: BannerParameters = BannerParameters()) {
@@ -113,15 +122,21 @@ extension OceanSwiftUI {
                 contentView(textToButtonSpacing: Ocean.size.spacingStackXxs)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.all, Ocean.size.spacingStackXs)
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear.preference(key: SmallContentHeightKey.self,
+                                                   value: proxy.size.height)
+                        }
+                    )
 
                 if hasImage {
                     bannerImage
-                        .frame(width: 82)
-                        .frame(maxHeight: .infinity)
+                        .frame(width: 82, height: smallContentHeight)
                         .clipped()
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            .onPreferenceChange(SmallContentHeightKey.self) { smallContentHeight = $0 }
         }
 
         private func contentView(textToButtonSpacing: CGFloat) -> some View {

--- a/Sources/OceanComponents/ComponentsSwiftUI/Button/OceanSwiftUI+Button.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Button/OceanSwiftUI+Button.swift
@@ -232,19 +232,36 @@ extension OceanSwiftUI {
         }
 
         public func makeBody(configuration: Self.Configuration) -> some View {
-            configuration.label
-                .font(Font(UIFont.baseBold(size: self.parameters.size.getFontSize())!))
-                .frame(maxWidth: self.parameters.maxWidth,
-                       minHeight: self.parameters.size.rawValue,
-                       idealHeight: self.parameters.size.rawValue,
-                       maxHeight: self.parameters.size.rawValue,
-                       alignment: .center)
-                .padding(.horizontal, getPadding())
-                .background(
-                    RoundedRectangle(cornerRadius: Ocean.size.borderRadiusCircular * self.parameters.size.rawValue)
-                        .fill(self.getBackgroundColor(configuration: configuration))
-                )
-                .foregroundColor(configuration.isPressed ? getPressedForegroundColor() : foregroundColor)
+            _OceanButtonBody(style: self, configuration: configuration)
+        }
+
+        private struct _OceanButtonBody: View {
+            let style: OceanButtonStyle
+            let configuration: ButtonStyleConfiguration
+            @State private var isHovered = false
+
+            var body: some View {
+                configuration.label
+                    .font(Font(UIFont.baseBold(size: style.parameters.size.getFontSize())!))
+                    .frame(maxWidth: style.parameters.maxWidth,
+                           minHeight: style.parameters.size.rawValue,
+                           idealHeight: style.parameters.size.rawValue,
+                           maxHeight: style.parameters.size.rawValue,
+                           alignment: .center)
+                    .padding(.horizontal, style.getPadding())
+                    .background(
+                        RoundedRectangle(cornerRadius: Ocean.size.borderRadiusCircular * style.parameters.size.rawValue)
+                            .fill(style.getBackgroundColor(configuration: configuration))
+                    )
+                    .foregroundColor(resolvedForegroundColor)
+                    .onHover { isHovered = $0 }
+            }
+
+            private var resolvedForegroundColor: Color {
+                if configuration.isPressed { return style.getPressedForegroundColor() }
+                if isHovered { return style.getHoverForegroundColor() }
+                return style.foregroundColor
+            }
         }
 
         public func getPadding() -> CGFloat {
@@ -266,7 +283,26 @@ extension OceanSwiftUI {
                 case .tertiaryCritical:
                     return Color(Ocean.color.colorStatusNegativeDeep)
                 case .tertiaryWarning:
-                    return Color(Ocean.color.colorStatusWarningDeep).mix(with: Color(Ocean.color.colorInterfaceDarkPure), by: 0.16)
+                    return foregroundColor
+                default:
+                    break
+                }
+            }
+
+            return foregroundColor
+        }
+
+        public func getHoverForegroundColor() -> Color {
+            guard !self.parameters.isDisabled else { return Color(Ocean.color.colorInterfaceDarkUp) }
+
+            if isHugMode {
+                switch self.parameters.style {
+                case .tertiary:
+                    return Color(Ocean.color.colorBrandPrimaryDown)
+                case .tertiaryCritical:
+                    return Color(Ocean.color.colorStatusNegativeDown)
+                case .tertiaryWarning:
+                    return Color(Ocean.color.colorStatusWarningDown)
                 default:
                     break
                 }


### PR DESCRIPTION
## Descrição

Implementa o componente `OceanSwiftUI.Banner` no Ocean Design System iOS, conforme especificação do PRD [ocean-ds/ocean-web#1247](https://github.com/ocean-ds/ocean-web/issues/1247) e Jira [MR-494](https://useblu.atlassian.net/browse/MR-494).

## Mudanças

- Novo componente `OceanSwiftUI.Banner` em `Sources/OceanComponents/ComponentsSwiftUI/Banner/`
- Demo view em `OceanDesignSystem/Controllers/Components SwiftUI/BannerSwiftUIViewController.swift`
- Banner adicionado ao menu de componentes SwiftUI do app de exemplo

## Variantes implementadas

- **Size:** `.large` (imagem no topo), `.small` (imagem à direita)
- **Type:** `.default`, `.warning`, `.negative`, `.emphasys`
- **Props opcionais:** `description`, `image`, `imageURL`, `buttons` (array, máx 2), `backgroundColor`

## Jira

MR-494