### PR TITLE
feat(switch): add disabled state to OceanSwiftUI.Switch

### DIFF
--- a/OceanDesignSystem/Controllers/Components SwiftUI/SwitchSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/SwitchSwiftUIViewController.swift
@@ -31,13 +31,31 @@ class SwitchSwiftUIViewController: UIViewController {
         }
     }()
 
+    private lazy var switchDisabledOffView: OceanSwiftUI.Switch = {
+        OceanSwiftUI.Switch { view in
+            view.parameters.isOn = false
+            view.parameters.isDisabled = true
+        }
+    }()
+
+    private lazy var switchDisabledOnView: OceanSwiftUI.Switch = {
+        OceanSwiftUI.Switch { view in
+            view.parameters.isOn = true
+            view.parameters.isDisabled = true
+        }
+    }()
+
     private lazy var hostingController = UIHostingController(rootView: ScrollView {
         VStack(alignment: .center, spacing: Ocean.size.spacingStackXs) {
             switchView
-            
+
             stateLabel
-            
+
             switchSkeltonView
+
+            switchDisabledOffView
+
+            switchDisabledOnView
         }
     })
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Switch/OceanSwiftUI+Switch.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Switch/OceanSwiftUI+Switch.swift
@@ -14,13 +14,16 @@ extension OceanSwiftUI {
 
     public class SwitchParameters: ObservableObject {
         @Published public var isOn: Bool
+        @Published public var isDisabled: Bool
         @Published public var showSkeleton: Bool
         public var onValueChanged: (Bool) -> Void
-        
+
         public init(isOn: Bool = false,
+                    isDisabled: Bool = false,
                     showSkeleton: Bool = false,
                     onValueChanged: @escaping (Bool) -> Void = { _ in }) {
             self.isOn = isOn
+            self.isDisabled = isDisabled
             self.showSkeleton = showSkeleton
             self.onValueChanged = onValueChanged
         }
@@ -58,7 +61,8 @@ extension OceanSwiftUI {
 
         public var body: some View {
             Toggle("", isOn: self.$parameters.isOn)
-                .toggleStyle(OceanSwitchStyle(onValueChanged: self.parameters.onValueChanged))
+                .toggleStyle(OceanSwitchStyle(isDisabled: self.parameters.isDisabled,
+                                              onValueChanged: self.parameters.onValueChanged))
                 .oceanSkeleton(isActive: self.parameters.showSkeleton, size: .init(width: 40, height: 20))
         }
 
@@ -66,33 +70,41 @@ extension OceanSwiftUI {
     }
     
     public struct OceanSwitchStyle: ToggleStyle {
+        public var isDisabled: Bool
         public var onValueChanged: (Bool) -> Void
-        
+
         let onColor = Color(Ocean.color.colorComplementaryPure)
         let offColor = Color(Ocean.color.colorInterfaceLightPure)
         let offThumbColor = Color(Ocean.color.colorInterfaceDarkUp)
         let onThumbColor = Color(Ocean.color.colorInterfaceLightPure)
         let onBorderColor = Ocean.color.colorComplementaryPure
         let offBorderColor = Ocean.color.colorInterfaceDarkUp
-        
-        init(onValueChanged: @escaping (Bool) -> Void) {
+        let disabledColor = Color(Ocean.color.colorInterfaceLightDown)
+        let disabledBorderColor = Ocean.color.colorInterfaceLightDown
+
+        init(isDisabled: Bool = false, onValueChanged: @escaping (Bool) -> Void) {
+            self.isDisabled = isDisabled
             self.onValueChanged = onValueChanged
         }
-        
+
         public func makeBody(configuration: Configuration) -> some View {
-            RoundedRectangle(cornerRadius: Ocean.size.borderRadiusLg, style: .circular)
-                .fill(configuration.isOn ? onColor : offColor)
+            let isEnabled = !self.isDisabled
+
+            return RoundedRectangle(cornerRadius: Ocean.size.borderRadiusLg, style: .circular)
+                .fill(configuration.isOn ? (isEnabled ? onColor : disabledColor) : offColor)
                 .frame(width: 40, height: 20)
                 .overlay(
                     Circle()
-                        .fill(configuration.isOn ? onThumbColor : offThumbColor)
+                        .fill(configuration.isOn ? onThumbColor : (isEnabled ? offThumbColor : disabledColor))
                         .padding(5)
                         .offset(x: configuration.isOn ? 10 : -10)
                 )
                 .border(cornerRadius: Ocean.size.borderRadiusLg,
                         width: Ocean.size.borderWidthHairline,
-                        color: configuration.isOn ? onBorderColor : offBorderColor)
+                        color: isEnabled ? (configuration.isOn ? onBorderColor : offBorderColor) : disabledBorderColor)
                 .onTapGesture {
+                    guard isEnabled else { return }
+
                     withAnimation(.smooth(duration: 0.2)) {
                         configuration.isOn.toggle()
                         self.onValueChanged(configuration.isOn)


### PR DESCRIPTION
## Description

Adds a disabled state to `OceanSwiftUI.Switch`, which previously had no way to be disabled at the component level.

- New `isDisabled: Bool = false` parameter on `SwitchParameters`.
- When disabled, the switch renders with the **same tokens as the Android `OceanSwitch`** (`SwitchDefaults.colors`): `colorInterfaceLightDown` for the track (when on), thumb (when off) and border. Enabled appearance is unchanged.
- When disabled, the switch ignores taps (no toggle / no `onValueChanged`).
- Added disabled examples (on and off) to `SwitchSwiftUIViewController`.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manually via the `SwitchSwiftUIViewController` demo screen in OceanDesignSystem, comparing the disabled appearance against the Android `OceanSwitch`.

## Screenshots (if appropriate):

<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 - 2026-06-19 at 09 41 09" src="https://github.com/user-attachments/assets/f92a10a9-ae56-4aef-b3b4-ee6b741703fa" />

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings