### PR TITLE
chore(fastlane): add update_certificate and get_certificate lanes

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,6 +46,21 @@ platform :ios do
     sh("git push")
   end
 
+  desc "Update certificate"
+  lane :update_certificate do
+    remove_profiles_step(type: 'development')
+    remove_profiles_step(type: 'appstore')
+
+    get_profiles_step(type: 'development')
+    get_profiles_step(type: 'appstore')
+  end
+
+  desc "Get certificate"
+  lane :get_certificate do
+    get_profiles_step(type: 'development')
+    get_profiles_step(type: 'appstore')
+  end
+
   desc "Upload to TestFlight"
   lane :beta_testflight do
     increment_build_number()
@@ -78,6 +93,21 @@ platform :ios do
       app_identifier: bundle_identifier,
       type: options[:type],
       readonly: is_ci
+    )
+  end
+
+  private_lane :remove_profiles_step do |options|
+    api_key = app_store_connect_api_key(
+      key_id: "#{ENV["APP_STORE_CONNECT_API_KEY_KEY_ID"]}",
+      issuer_id: "#{ENV["APP_STORE_CONNECT_API_KEY_ISSUER_ID"]}",
+      key_content: "#{ENV["APP_STORE_CONNECT_API_KEY_KEY"]}".gsub('\n', '\\n'),
+      in_house: false
+    )
+
+    match_nuke(
+      api_key: api_key,
+      git_basic_authorization: "#{ENV["MATCH_GIT_BASIC_AUTHORIZATION"]}",
+      type: options[:type]
     )
   end
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -33,6 +33,22 @@ Build and Test App
 
 Prepare new version on master
 
+### ios update_certificate
+
+```sh
+[bundle exec] fastlane ios update_certificate
+```
+
+Update certificate
+
+### ios get_certificate
+
+```sh
+[bundle exec] fastlane ios get_certificate
+```
+
+Get certificate
+
 ### ios beta_testflight
 
 ```sh


### PR DESCRIPTION
## O que muda

Adiciona duas lanes de gestão de certificados/profiles no fastlane do ocean-ios, espelhando o que já existe no `blu-mobile-ios` e adaptado ao ocean-ios (único bundle id `br.com.blu.ocean.DesignSystem`, apenas tipos `development` e `appstore`).

- **`update_certificate`** — apaga os profiles (`match_nuke`) de `development` e `appstore` e recria em seguida (`match`).
- **`get_certificate`** — apenas baixa/garante os profiles existentes de `development` e `appstore`.
- **`remove_profiles_step`** (private lane) — novo helper com `match_nuke`, seguindo o mesmo padrão de auth do projeto.

## Detalhes

- Autenticação via `app_store_connect_api_key` + `git_basic_authorization`, igual ao restante do Fastfile — **não exige SMS/2FA**.
- `match_nuke` mantém a confirmação interativa por padrão (sem `skip_confirmation`), preservando a trava de segurança, igual ao blu-mobile-ios.
- README do fastlane atualizado com as novas lanes.

## Como rodar

```sh
bundle exec fastlane update_certificate   # apaga e recria
bundle exec fastlane get_certificate      # apenas baixa
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)