### PR TITLE
ci: use latest-stable for CD Xcode

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.5'
+          xcode-version: latest-stable
 
       - name: Set git identity
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Select xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '26.1'
+          xcode-version: '26.5'
 
       - name: Set git identity
         run: |


### PR DESCRIPTION
## O que

Troca a versão fixa do Xcode no workflow de CD por `latest-stable`.

## Por quê

O CD estava falhando no `build_app` (exit 70) com:

```
xcodebuild: error: Unable to find a destination matching the provided destination specifier:
    { generic:1, platform:iOS }
    ...
    error:iOS 26.1 is not installed.
```

O runner `macos-26` resolvia o `xcode-version: '26.1'` para o Xcode 26.1.1, que **não tinha a plataforma/SDK do iOS 26.1 instalada**. Sem o SDK, o destino `generic/platform=iOS` não existe e o archive não roda.

Em vez de pinar uma versão específica (que volta a quebrar quando o runner muda), usa `latest-stable` para sempre selecionar o Xcode estável mais recente disponível no runner, que vem com o SDK iOS instalado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)