### PR TITLE
feat(transaction-footer): suporte a divider e bold no valor ativo

### DIFF
--- a/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
@@ -30,10 +30,14 @@ class TransactionFooterSwiftUIViewController: UIViewController {
                   imageIcon: Ocean.icon.tagSolid),
             .init(text: "Valor cobrado", 
                   value: "R$ 100.000,00"),
-            .init(text: "Custo de antecipação", 
-                  value: "R$ 10,00",
-                  newValue: "Zero"),
-            .init(text: "Pague", 
+            .init(text: "Juros do parcelamento",
+                  value: "4,39%",
+                  valueColor: Ocean.color.colorStatusPositiveDeep,
+                  isBoldValue: true,
+                  newValue: "Grátis",
+                  newValueColor: Ocean.color.colorStatusPositiveDeep),
+            .init(isDivider: true),
+            .init(text: "Pague",
                   value: "R$ 10,00",
                   isBoldValue: true)
         ]

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -58,6 +58,7 @@ extension OceanSwiftUI {
             @Published public var caption: String
             @Published public var imageIcon: UIImage?
             @Published public var imageColor: UIColor
+            @Published public var isDivider: Bool
 
             public init(text: String = "",
                         value: String = "",
@@ -67,7 +68,8 @@ extension OceanSwiftUI {
                         newValueColor: UIColor = Ocean.color.colorStatusPositiveDeep,
                         caption: String = "",
                         imageIcon: UIImage? = nil,
-                        imageColor: UIColor = Ocean.color.colorStatusPositiveDeep) {
+                        imageColor: UIColor = Ocean.color.colorStatusPositiveDeep,
+                        isDivider: Bool = false) {
                 self.text = text
                 self.value = value
                 self.valueColor = valueColor
@@ -77,6 +79,7 @@ extension OceanSwiftUI {
                 self.caption = caption
                 self.imageIcon = imageIcon
                 self.imageColor = imageColor
+                self.isDivider = isDivider
             }
         }
     }
@@ -139,6 +142,9 @@ extension OceanSwiftUI {
 
         @ViewBuilder
         private func getItemView(item: TransactionFooterParameters.ItemModel) -> some View {
+            if item.isDivider {
+                OceanSwiftUI.Divider()
+            } else {
             VStack(alignment: .leading, spacing: 0) {
                 HStack {
                     Typography.paragraph { label in
@@ -161,9 +167,13 @@ extension OceanSwiftUI {
                             label.parameters.textColor = item.valueColor
                             label.parameters.strikethrough = true
                         }
+                        // newValue é o valor "ativo": pode ser bold quando isBoldValue.
                         Typography.paragraph { label in
                             label.parameters.text = item.newValue
                             label.parameters.textColor = item.newValueColor
+                            label.parameters.font = item.isBoldValue
+                                ? .baseBold(size: Ocean.font.fontSizeXs)
+                                : .baseRegular(size: Ocean.font.fontSizeXs)
                         }
                     } else {
                         Typography.paragraph { label in
@@ -183,6 +193,7 @@ extension OceanSwiftUI {
                     }
                     .padding(.top, Ocean.size.spacingStackXxs)
                 }
+            }
             }
         }
 


### PR DESCRIPTION
## O que

Dois ajustes no `OceanSwiftUI.TransactionFooter` (resumo):

1. **Divider**: novo campo `TransactionFooterParameters.ItemModel.isDivider`. Quando `true`, o item renderiza um `OceanSwiftUI.Divider` em vez da linha `text`/`value`. Permite divisores no meio do resumo.
2. **Bold no valor ativo**: quando há `newValue`, o `newValue` passa a respeitar `isBoldValue` (antes só o branch sem `newValue` aplicava bold). O `value` riscado continua regular.

## Por quê

Apps PagBlu precisam renderizar o resumo de `payment_options` com divisores entre grupos e com o valor ativo em negrito — hoje o componente não suporta divider e ignorava `isBoldValue` quando havia `newValue`.

## Como testar

`TransactionFooterSwiftUIViewController` (demo) atualizado com um item `newValue` + `isBoldValue` e um item `isDivider`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)