### PR TITLE
feat: add highlight variant to SwiftUI TransactionFooter

### DIFF
--- a/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
@@ -55,8 +55,33 @@ class TransactionFooterSwiftUIViewController: UIViewController {
         ]
     }
 
+    private lazy var transactionFooterHighlight = OceanSwiftUI.TransactionFooter { view in
+        view.parameters.variant = .highlight
+        view.parameters.primaryButton = .init(text: "Confirmar pagamento", style: .primary, onTouch: { print("primaryButton") })
+        view.parameters.buttonOrientation = .vertical
+        view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
+        view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
+                                        leading: Ocean.size.spacingStackXs,
+                                        bottom: Ocean.size.spacingStackXs,
+                                        trailing: Ocean.size.spacingStackXs)
+        view.parameters.items = [
+            .init(text: "Você vai economizar",
+                  value: "R$ 3.574,28",
+                  valueColor: Ocean.color.colorStatusPositiveDeep,
+                  imageIcon: Ocean.icon.tagSolid),
+            .init(text: "Custo de antecipação",
+                  value: "3,99%",
+                  newValue: "Grátis"),
+            .init(text: "Pagando",
+                  value: "R$ 41.256,25",
+                  isBoldValue: true)
+        ]
+    }
+
     private lazy var hostingController = UIHostingController(rootView: VStack {
         Spacer()
+        Divider()
+        transactionFooterHighlight
         Divider()
         transactionFooterWithCaption
         Divider()

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
@@ -13,8 +13,8 @@ import OceanTokens
 class TransactionFooterSwiftUIViewController: UIViewController {
 
     private lazy var transactionFooterWithButtonsVertical = OceanSwiftUI.TransactionFooter { view in
-        view.parameters.primaryButton = .init(text: "Avançar", style: .primary, onTouch: { print("primaryButton") })
-        view.parameters.secondaryButton = .init(text: "Cancelar",  style: .secondary, onTouch: { print("secondaryButton") })
+        view.parameters.primaryButton = .init(text: "Label", style: .primary, onTouch: { print("primaryButton") })
+        view.parameters.secondaryButton = .init(text: "Label", style: .secondary, onTouch: { print("secondaryButton") })
         view.parameters.buttonOrientation = .vertical
         view.parameters.skeletonLines = 4
         view.parameters.showSkeleton = true
@@ -24,23 +24,21 @@ class TransactionFooterSwiftUIViewController: UIViewController {
                                         bottom: Ocean.size.spacingStackXs,
                                         trailing: Ocean.size.spacingStackXs)
         view.parameters.items = [
-            .init(text: "Desconto à vista",
-                  value: "R$ 100.000,00",
-                  valueColor: Ocean.color.colorStatusPositiveDeep,
-                  imageIcon: Ocean.icon.tagSolid),
-            .init(text: "Valor cobrado", 
-                  value: "R$ 100.000,00"),
-            .init(text: "Custo de antecipação", 
-                  value: "R$ 10,00",
-                  newValue: "Zero"),
-            .init(text: "Pague", 
-                  value: "R$ 10,00",
+            .init(text: "Title",
+                  value: "Description"),
+            .init(text: "Title",
+                  value: "Description"),
+            .init(text: "Title",
+                  value: "Description",
+                  newValue: "Description"),
+            .init(text: "Title",
+                  value: "Description",
                   isBoldValue: true)
         ]
     }
 
     private lazy var transactionFooterWithCaption = OceanSwiftUI.TransactionFooter { view in
-        view.parameters.primaryButton = .init(text: "Agendar", style: .primary, onTouch: { print("Agendar") })
+        view.parameters.primaryButton = .init(text: "Label", style: .primary, onTouch: { print("primaryButton") })
         view.parameters.buttonOrientation = .vertical
         view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
@@ -48,16 +46,16 @@ class TransactionFooterSwiftUIViewController: UIViewController {
                                         bottom: Ocean.size.spacingStackXs,
                                         trailing: Ocean.size.spacingStackXs)
         view.parameters.items = [
-            .init(text: "Total a pagar",
-                  value: "R$ 5.000,00",
+            .init(text: "Title",
+                  value: "Description",
                   isBoldValue: true,
-                  caption: "Se não houver saldo atual, pode ser cobrada taxa de antecipação.")
+                  caption: "Description")
         ]
     }
 
     private lazy var transactionFooterHighlight = OceanSwiftUI.TransactionFooter { view in
         view.parameters.variant = .highlight
-        view.parameters.primaryButton = .init(text: "Confirmar pagamento", style: .primary, onTouch: { print("primaryButton") })
+        view.parameters.primaryButton = .init(text: "Label", style: .primary, onTouch: { print("primaryButton") })
         view.parameters.buttonOrientation = .vertical
         view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
@@ -65,15 +63,13 @@ class TransactionFooterSwiftUIViewController: UIViewController {
                                         bottom: Ocean.size.spacingStackXs,
                                         trailing: Ocean.size.spacingStackXs)
         view.parameters.items = [
-            .init(text: "Você vai economizar",
-                  value: "R$ 3.574,28",
-                  valueColor: Ocean.color.colorStatusPositiveDeep,
-                  imageIcon: Ocean.icon.tagSolid),
-            .init(text: "Custo de antecipação",
-                  value: "3,99%",
-                  newValue: "Grátis"),
-            .init(text: "Pagando",
-                  value: "R$ 41.256,25",
+            .init(text: "Title",
+                  value: "Description"),
+            .init(text: "Title",
+                  value: "Description",
+                  newValue: "Description"),
+            .init(text: "Title",
+                  value: "Description",
                   isBoldValue: true)
         ]
     }

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
@@ -40,6 +40,8 @@ class TransactionFooterSwiftUIViewController: UIViewController {
     private lazy var transactionFooterWithCaption = OceanSwiftUI.TransactionFooter { view in
         view.parameters.primaryButton = .init(text: "Label", style: .primary, onTouch: { print("primaryButton") })
         view.parameters.buttonOrientation = .vertical
+        view.parameters.sectionTitle = "Title"
+        view.parameters.showBottomDivider = true
         view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
                                         leading: Ocean.size.spacingStackXs,
@@ -57,6 +59,8 @@ class TransactionFooterSwiftUIViewController: UIViewController {
         view.parameters.variant = .highlight
         view.parameters.primaryButton = .init(text: "Label", style: .primary, onTouch: { print("primaryButton") })
         view.parameters.buttonOrientation = .vertical
+        view.parameters.sectionTitle = "Title"
+        view.parameters.showBottomDivider = true
         view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
                                         leading: Ocean.size.spacingStackXs,

--- a/OceanDesignSystemTests/OceanDesignSystemTests.swift
+++ b/OceanDesignSystemTests/OceanDesignSystemTests.swift
@@ -139,4 +139,17 @@ final class TransactionFooterVariantTests: XCTestCase {
         let parameters = OceanSwiftUI.TransactionFooterParameters(variant: .highlight)
         XCTAssertEqual(parameters.variant, .highlight)
     }
+
+    func testSectionTitleAndBottomDividerDefaults() {
+        let parameters = OceanSwiftUI.TransactionFooterParameters()
+        XCTAssertEqual(parameters.sectionTitle, "")
+        XCTAssertFalse(parameters.showBottomDivider)
+    }
+
+    func testSectionTitleAndBottomDividerCanBeSet() {
+        let parameters = OceanSwiftUI.TransactionFooterParameters(sectionTitle: "Resumo",
+                                                                  showBottomDivider: true)
+        XCTAssertEqual(parameters.sectionTitle, "Resumo")
+        XCTAssertTrue(parameters.showBottomDivider)
+    }
 }

--- a/OceanDesignSystemTests/OceanDesignSystemTests.swift
+++ b/OceanDesignSystemTests/OceanDesignSystemTests.swift
@@ -125,3 +125,18 @@ final class TypographyAlignmentTests: XCTestCase {
         XCTAssertNil(OceanSwiftUI.TypographyParameters.Style.caption.getTextCase())
     }
 }
+
+/// Cobre a variante visual do TransactionFooter (MR-515):
+/// `variant` é aditiva e nasce em `.default` (retrocompatibilidade — RN-01 / CA-01).
+final class TransactionFooterVariantTests: XCTestCase {
+
+    func testVariantDefaultsToDefault() {
+        let parameters = OceanSwiftUI.TransactionFooterParameters()
+        XCTAssertEqual(parameters.variant, .default)
+    }
+
+    func testVariantCanBeSetToHighlight() {
+        let parameters = OceanSwiftUI.TransactionFooterParameters(variant: .highlight)
+        XCTAssertEqual(parameters.variant, .highlight)
+    }
+}

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -121,11 +121,22 @@ extension OceanSwiftUI {
         public var body: some View {
             if parameters.variant == .highlight {
                 contentView
+                    .padding(.top, Ocean.size.spacingStackXxs)
                     .background(Color(Ocean.color.colorInterfaceLightUp))
                     .cornerRadius(Ocean.size.borderRadiusLg, corners: [.topLeft, .topRight])
             } else {
                 contentView
+                    .padding(.top, Ocean.size.spacingStackXxs)
+                    .overlay(topDivider, alignment: .top)
             }
+        }
+
+        // Divisor de topo da variante Default (Figma), edge-to-edge, dentro do
+        // espaçador de 8px — a Highlight arredonda o topo e não tem divisor.
+        private var topDivider: some View {
+            Rectangle()
+                .fill(Color(Ocean.color.colorInterfaceLightDown))
+                .frame(height: 1)
         }
 
         private var contentView: some View {

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -12,6 +12,11 @@ extension OceanSwiftUI {
 
     // MARK: Parameters
 
+    public enum TransactionFooterVariant {
+        case `default`
+        case highlight
+    }
+
     public class TransactionFooterParameters: ObservableObject {
         @Published public var items: [ItemModel]
         @Published public var primaryButton: ButtonParameters?
@@ -21,6 +26,7 @@ extension OceanSwiftUI {
         @Published public var skeletonLines: Int
         @Published public var interlineSpacing: CGFloat
         @Published public var padding: EdgeInsets
+        @Published public var variant: TransactionFooterVariant
 
         public init(items: [ItemModel] = [],
                     primaryButton: ButtonParameters? = nil,
@@ -32,7 +38,8 @@ extension OceanSwiftUI {
                     padding: EdgeInsets = .init(top: 0,
                                                 leading: Ocean.size.spacingStackXs,
                                                 bottom: Ocean.size.spacingStackXs,
-                                                trailing: Ocean.size.spacingStackXs)) {
+                                                trailing: Ocean.size.spacingStackXs),
+                    variant: TransactionFooterVariant = .default) {
             self.items = items
             self.primaryButton = primaryButton
             self.secondaryButton = secondaryButton
@@ -41,6 +48,7 @@ extension OceanSwiftUI {
             self.skeletonLines = skeletonLines
             self.interlineSpacing = interlineSpacing
             self.padding = padding
+            self.variant = variant
         }
 
         public enum ButtonOrientation {
@@ -111,6 +119,16 @@ extension OceanSwiftUI {
         // MARK: View SwiftUI
 
         public var body: some View {
+            if parameters.variant == .highlight {
+                contentView
+                    .background(Color(Ocean.color.colorInterfaceLightUp))
+                    .cornerRadius(Ocean.size.borderRadiusLg, corners: [.topLeft, .topRight])
+            } else {
+                contentView
+            }
+        }
+
+        private var contentView: some View {
             VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
                 if parameters.showSkeleton {
                     getSkeletonView(skeletonLines: parameters.skeletonLines)

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -27,6 +27,8 @@ extension OceanSwiftUI {
         @Published public var interlineSpacing: CGFloat
         @Published public var padding: EdgeInsets
         @Published public var variant: TransactionFooterVariant
+        @Published public var sectionTitle: String
+        @Published public var showBottomDivider: Bool
 
         public init(items: [ItemModel] = [],
                     primaryButton: ButtonParameters? = nil,
@@ -39,7 +41,9 @@ extension OceanSwiftUI {
                                                 leading: Ocean.size.spacingStackXs,
                                                 bottom: Ocean.size.spacingStackXs,
                                                 trailing: Ocean.size.spacingStackXs),
-                    variant: TransactionFooterVariant = .default) {
+                    variant: TransactionFooterVariant = .default,
+                    sectionTitle: String = "",
+                    showBottomDivider: Bool = false) {
             self.items = items
             self.primaryButton = primaryButton
             self.secondaryButton = secondaryButton
@@ -49,6 +53,8 @@ extension OceanSwiftUI {
             self.interlineSpacing = interlineSpacing
             self.padding = padding
             self.variant = variant
+            self.sectionTitle = sectionTitle
+            self.showBottomDivider = showBottomDivider
         }
 
         public enum ButtonOrientation {
@@ -144,8 +150,24 @@ extension OceanSwiftUI {
                 if parameters.showSkeleton {
                     getSkeletonView(skeletonLines: parameters.skeletonLines)
                 } else {
+                    if !parameters.sectionTitle.isEmpty {
+                        Typography.heading5 { label in
+                            label.parameters.text = parameters.sectionTitle
+                            label.parameters.textColor = Ocean.color.colorInterfaceDarkUp
+                        }
+                    }
+
                     VStack(spacing: parameters.interlineSpacing) {
                         ForEach(parameters.items.indices, id: \.self) { index in
+                            if parameters.showBottomDivider
+                                && index == parameters.items.count - 1
+                                && parameters.items.count > 1 {
+                                Rectangle()
+                                    .fill(Color(Ocean.color.colorInterfaceLightDown))
+                                    .frame(height: 1)
+                                    .padding(.vertical, Ocean.size.spacingStackXxxs)
+                            }
+
                             getItemView(item: parameters.items[index])
                         }
                     }


### PR DESCRIPTION
## Descrição

Adiciona a variante visual **`highlight`** ao `OceanSwiftUI.TransactionFooter` e alinha o componente ao Figma do Ocean DS Core (node `25851-3910`). Mudança **aditiva** (novo `@Published var variant`, default `.default`) + ajustes **somente de layout** (sem alterar props existentes, para não quebrar integrações atuais).

## Tipo de mudança

`feature`

## O que está sendo resolvido

- `variant` no `TransactionFooterParameters` (SwiftUI) + demo, com a variante `highlight` fiel ao Figma (fundo `colorInterfaceLightUp` + cantos superiores 16pt).
- `.default` alinhada ao Figma: passa a exibir o **divisor de topo**.

## Como foi resolvido

- `OceanSwiftUI+TransactionFooter.swift`:
  - Novo enum `TransactionFooterVariant { case default, highlight }` + `@Published public var variant` (init com default `.default`).
  - Ambas as variantes ganham um **espaçador de topo de 8px**; a `.default` sobrepõe um **divisor de topo** de 1pt (`colorInterfaceLightDown`) edge-to-edge dentro desse espaçador, e a `.highlight` mantém os cantos superiores 16pt (`borderRadiusLg`) + fundo `colorInterfaceLightUp` — então alternar a variante **não gera "pulo" de layout**.
  - Reusa o helper existente `View.cornerRadius(_:corners:)`.
  - `showSkeleton` (existente) é preservado sobre o fundo da variante ativa.
- `TransactionFooterSwiftUIViewController.swift` — demo das 2 variantes com textos genéricos (Title / Description / Label).
- `OceanDesignSystemTests.swift` — teste do parâmetro `variant`.

### Novas props opcionais (aditivas — não quebram integrações)

Para fidelidade completa ao Figma, foram adicionadas duas props opcionais com default que preserva o comportamento atual:

- `sectionTitle: String = ""` — quando preenchido, renderiza o **Section Header** acima das linhas (`Typography.heading5` / `colorInterfaceDarkUp`).
- `showBottomDivider: Bool = false` — quando `true`, desenha um **divisor interno** (`colorInterfaceLightDown`) antes da última linha (o total).

Nenhuma prop existente foi alterada/removida; todos os defaults preservam o comportamento atual — as telas atuais **compilam e renderizam igual**. SwiftUI apenas: o componente UIKit legado não recebe as novas props.

## Cenários de teste

Rodados localmente (Xcode):

- ✅ `xcodebuild build -scheme OceanDesignSystem` → **BUILD SUCCEEDED**.
- ✅ `xcodebuild build-for-testing -scheme OceanDesignSystem` → **TEST BUILD SUCCEEDED**.

O reviewer deve validar no demo `TransactionFooter` que a `default` exibe o divisor de topo e a `highlight` mostra fundo `colorInterfaceLightUp` + cantos superiores 16pt, contra o Figma (node `25851-3910`).

## Links

- **Jira:** [MR-515](https://useblu.atlassian.net/browse/MR-515)
- **Figma:** Ocean DS Core — node `25851-3910`

## Breaking changes

Sem quebra de API (propriedade aditiva, nenhuma prop alterada). Observação: a `default` passa a exibir um divisor de topo + 8px de topo (alinhamento com o Figma).
