### PR TITLE
feat(card-list-item): adiciona .above e .below ao tagPosition

### DIFF
--- a/OceanDesignSystem.xcodeproj/project.pbxproj
+++ b/OceanDesignSystem.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				OceanDesignSystemTests.swift,
+				CardListItemTagPositionTests.swift,
 			);
 			target = 24C8014E2682585600744F30 /* OceanDesignSystemTests */;
 		};

--- a/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
@@ -20,6 +20,7 @@ class CardListItemSwiftUIViewController: UIViewController {
         @Published var hasCaption: Bool = true
         @Published var hasTag: Bool = false
         @Published var tagPosition: OceanSwiftUI.CardListItemParameters.TagPosition = .leading
+        @Published var tagSize: OceanSwiftUI.TagParameters.Size = .medium
         @Published var tagStatus: OceanSwiftUI.TagParameters.Status = .neutralPrimary
         @Published var hasHighlight: Bool = false
         @Published var hasHighlightIcon: Bool = true
@@ -95,6 +96,7 @@ private struct CardListItemPreviewView: View {
             .onChange(of: state.hasCaption)       { _ in updateCard() }
             .onChange(of: state.hasTag)           { _ in updateCard() }
             .onChange(of: state.tagPosition)      { _ in updateCard() }
+            .onChange(of: state.tagSize)          { _ in updateCard() }
             .onChange(of: state.tagStatus)        { _ in updateCard() }
             .onChange(of: state.hasHighlight)     { _ in updateCard() }
             .onChange(of: state.hasHighlightIcon) { _ in updateCard() }
@@ -138,6 +140,16 @@ private struct CardListItemPreviewView: View {
                                 Text("Trailing").tag(OceanSwiftUI.CardListItemParameters.TagPosition.trailing)
                                 Text("Above").tag(OceanSwiftUI.CardListItemParameters.TagPosition.above)
                                 Text("Below").tag(OceanSwiftUI.CardListItemParameters.TagPosition.below)
+                            }
+                            .pickerStyle(SegmentedPickerStyle())
+
+                            Text("Size")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+
+                            Picker("Tag Size", selection: $state.tagSize) {
+                                Text("Medium (8pt)").tag(OceanSwiftUI.TagParameters.Size.medium)
+                                Text("Small (4pt)").tag(OceanSwiftUI.TagParameters.Size.small)
                             }
                             .pickerStyle(SegmentedPickerStyle())
 
@@ -235,6 +247,7 @@ private struct CardListItemPreviewView: View {
         card.parameters.caption = state.hasCaption ? "Caption" : ""
         card.parameters.tagLabel = state.hasTag ? "Tag" : ""
         card.parameters.tagPosition = state.tagPosition
+        card.parameters.tagSize = state.tagSize
         card.parameters.tagStatus = state.tagStatus
         card.parameters.highlightCaption = state.hasHighlight ? "This is a highlight message for this card item." : ""
         card.parameters.highlightIcon = state.hasHighlight && state.hasHighlightIcon ? Ocean.icon.sparklesSolid : nil
@@ -278,6 +291,7 @@ struct CardListItemTagPosition_Preview: PreviewProvider {
             view.parameters.caption = "Caption"
             view.parameters.tagLabel = "3x sem acréscimo"
             view.parameters.tagStatus = .positive
+            view.parameters.tagSize = .medium
             view.parameters.tagPosition = position
             view.parameters.hasRadioButton = selectable
             view.parameters.isChecked = selectable

--- a/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
@@ -136,6 +136,8 @@ private struct CardListItemPreviewView: View {
                             Picker("Tag Position", selection: $state.tagPosition) {
                                 Text("Leading").tag(OceanSwiftUI.CardListItemParameters.TagPosition.leading)
                                 Text("Trailing").tag(OceanSwiftUI.CardListItemParameters.TagPosition.trailing)
+                                Text("Above").tag(OceanSwiftUI.CardListItemParameters.TagPosition.above)
+                                Text("Below").tag(OceanSwiftUI.CardListItemParameters.TagPosition.below)
                             }
                             .pickerStyle(SegmentedPickerStyle())
 
@@ -257,5 +259,42 @@ struct CardListItemSwiftUIViewController_Preview: PreviewProvider {
         UIViewControllerPreview {
             CardListItemSwiftUIViewController()
         }
+    }
+}
+
+/// As quatro posições de tag lado a lado (MR-555). `.leading` e `.trailing` são o
+/// comportamento atual; `.above` e `.below` empilham dentro do bloco de conteúdo.
+@available(iOS 14.0, *)
+struct CardListItemTagPosition_Preview: PreviewProvider {
+
+    private static func card(
+        _ title: String,
+        _ position: OceanSwiftUI.CardListItemParameters.TagPosition,
+        selectable: Bool = false
+    ) -> some View {
+        OceanSwiftUI.CardListItem { view in
+            view.parameters.title = title
+            view.parameters.subtitle = "Pague em até 3x"
+            view.parameters.caption = "Caption"
+            view.parameters.tagLabel = "3x sem acréscimo"
+            view.parameters.tagStatus = .positive
+            view.parameters.tagPosition = position
+            view.parameters.hasRadioButton = selectable
+            view.parameters.isChecked = selectable
+        }
+    }
+
+    static var previews: some View {
+        ScrollView {
+            VStack(spacing: Ocean.size.spacingStackXs) {
+                card(".leading (default)", .leading)
+                card(".trailing", .trailing)
+                card(".above", .above)
+                card(".below", .below)
+                card(".above + radio (caso MR-523)", .above, selectable: true)
+            }
+            .padding(Ocean.size.spacingStackXs)
+        }
+        .previewDisplayName("Tag position")
     }
 }

--- a/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/CardListItemSwiftUIViewController.swift
@@ -275,8 +275,8 @@ struct CardListItemSwiftUIViewController_Preview: PreviewProvider {
     }
 }
 
-/// As quatro posições de tag lado a lado (MR-555). `.leading` e `.trailing` são o
-/// comportamento atual; `.above` e `.below` empilham dentro do bloco de conteúdo.
+/// The four tag positions side by side (MR-555). `.leading` and `.trailing` are the
+/// current behaviour; `.above` and `.below` stack it inside the content block.
 @available(iOS 14.0, *)
 struct CardListItemTagPosition_Preview: PreviewProvider {
 

--- a/OceanDesignSystemTests/CardListItemTagPositionTests.swift
+++ b/OceanDesignSystemTests/CardListItemTagPositionTests.swift
@@ -1,0 +1,119 @@
+//
+//  CardListItemTagPositionTests.swift
+//  OceanDesignSystemTests
+//
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+import OceanTokens
+@testable import OceanComponents
+
+/// Cobre a prop `tagPosition` do CardListItem (MR-555 / MR-552): os valores `.above` e
+/// `.below` acrescentados, e a não-regressão dos valores preexistentes (RN-01).
+///
+/// O repositório não tem infraestrutura de snapshot, então a verificação aqui é de API e
+/// de contrato de parâmetros; a fidelidade visual das posições é validada no app de showcase.
+final class CardListItemTagPositionTests: XCTestCase {
+
+    // MARK: - RN-01: o default não muda
+
+    func testDefaultTagPositionIsLeading() {
+        let parameters = OceanSwiftUI.CardListItemParameters()
+
+        XCTAssertEqual(parameters.tagPosition, .leading)
+    }
+
+    func testDefaultTagPositionIsPreservedWhenOtherParametersAreSet() {
+        let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
+                                                             subtitle: "Subtitle",
+                                                             tagLabel: "3x sem acréscimo")
+
+        XCTAssertEqual(parameters.tagPosition, .leading)
+    }
+
+    func testTrailingRemainsAssignable() {
+        let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
+                                                             tagLabel: "3x sem acréscimo",
+                                                             tagPosition: .trailing)
+
+        XCTAssertEqual(parameters.tagPosition, .trailing)
+    }
+
+    // MARK: - Valores novos
+
+    func testAboveIsAssignableViaInitializer() {
+        let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
+                                                             subtitle: "Subtitle",
+                                                             caption: "Caption",
+                                                             tagLabel: "3x sem acréscimo",
+                                                             tagPosition: .above)
+
+        XCTAssertEqual(parameters.tagPosition, .above)
+    }
+
+    func testBelowIsAssignableViaInitializer() {
+        let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
+                                                             subtitle: "Subtitle",
+                                                             caption: "Caption",
+                                                             tagLabel: "3x sem acréscimo",
+                                                             tagPosition: .below)
+
+        XCTAssertEqual(parameters.tagPosition, .below)
+    }
+
+    func testTagPositionIsMutableAfterInit() {
+        let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
+                                                             tagLabel: "3x sem acréscimo")
+        parameters.tagPosition = .above
+
+        XCTAssertEqual(parameters.tagPosition, .above)
+    }
+
+    /// O `switch` exaustivo é a prova de compilação de que o enum tem exatamente estes quatro
+    /// casos — se alguém acrescentar ou remover um valor, este teste deixa de compilar.
+    func testTagPositionHasExactlyFourCases() {
+        let allCases: [OceanSwiftUI.CardListItemParameters.TagPosition] =
+            [.leading, .trailing, .above, .below]
+
+        for position in allCases {
+            switch position {
+            case .leading, .trailing, .above, .below:
+                continue
+            }
+        }
+
+        XCTAssertEqual(allCases.count, 4)
+    }
+
+    // MARK: - Construção da view com cada posição
+
+    func testViewIsBuiltForEveryTagPosition() {
+        let positions: [OceanSwiftUI.CardListItemParameters.TagPosition] =
+            [.leading, .trailing, .above, .below]
+
+        for position in positions {
+            let view = OceanSwiftUI.CardListItem { card in
+                card.parameters.title = "Title"
+                card.parameters.subtitle = "Subtitle"
+                card.parameters.caption = "Caption"
+                card.parameters.tagLabel = "3x sem acréscimo"
+                card.parameters.tagPosition = position
+                card.parameters.hasRadioButton = true
+            }
+
+            XCTAssertEqual(view.parameters.tagPosition, position)
+        }
+    }
+
+    func testViewIsBuiltWithoutTagWhenPositionIsSet() {
+        let view = OceanSwiftUI.CardListItem { card in
+            card.parameters.title = "Title"
+            card.parameters.tagPosition = .above
+        }
+
+        XCTAssertTrue(view.parameters.tagLabel.isEmpty)
+        XCTAssertEqual(view.parameters.tagPosition, .above)
+    }
+}

--- a/OceanDesignSystemTests/CardListItemTagPositionTests.swift
+++ b/OceanDesignSystemTests/CardListItemTagPositionTests.swift
@@ -10,14 +10,14 @@ import SwiftUI
 import OceanTokens
 @testable import OceanComponents
 
-/// Cobre a prop `tagPosition` do CardListItem (MR-555 / MR-552): os valores `.above` e
-/// `.below` acrescentados, e a não-regressão dos valores preexistentes (RN-01).
+/// Covers the CardListItem `tagPosition` prop (MR-555 / MR-552): the newly added
+/// `.above` and `.below` values, and the non-regression of the pre-existing ones (RN-01).
 ///
-/// O repositório não tem infraestrutura de snapshot, então a verificação aqui é de API e
-/// de contrato de parâmetros; a fidelidade visual das posições é validada no app de showcase.
+/// The repository has no snapshot infrastructure, so the checks here are on the API and the
+/// parameter contract; the visual fidelity of the positions is validated in the showcase app.
 final class CardListItemTagPositionTests: XCTestCase {
 
-    // MARK: - RN-01: o default não muda
+    // MARK: - RN-01: the default does not change
 
     func testDefaultTagPositionIsLeading() {
         let parameters = OceanSwiftUI.CardListItemParameters()
@@ -41,7 +41,7 @@ final class CardListItemTagPositionTests: XCTestCase {
         XCTAssertEqual(parameters.tagPosition, .trailing)
     }
 
-    // MARK: - Valores novos
+    // MARK: - New values
 
     func testAboveIsAssignableViaInitializer() {
         let parameters = OceanSwiftUI.CardListItemParameters(title: "Title",
@@ -71,8 +71,8 @@ final class CardListItemTagPositionTests: XCTestCase {
         XCTAssertEqual(parameters.tagPosition, .above)
     }
 
-    /// O `switch` exaustivo é a prova de compilação de que o enum tem exatamente estes quatro
-    /// casos — se alguém acrescentar ou remover um valor, este teste deixa de compilar.
+    /// The exhaustive `switch` is compile-time proof that the enum has exactly these four
+    /// cases — if anyone adds or removes a value, this test stops compiling.
     func testTagPositionHasExactlyFourCases() {
         let allCases: [OceanSwiftUI.CardListItemParameters.TagPosition] =
             [.leading, .trailing, .above, .below]
@@ -87,7 +87,7 @@ final class CardListItemTagPositionTests: XCTestCase {
         XCTAssertEqual(allCases.count, 4)
     }
 
-    // MARK: - Construção da view com cada posição
+    // MARK: - Building the view with each position
 
     func testViewIsBuiltForEveryTagPosition() {
         let positions: [OceanSwiftUI.CardListItemParameters.TagPosition] =

--- a/Sources/OceanComponents/ComponentsSwiftUI/CardListItem/OceanSwiftUI+CardListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/CardListItem/OceanSwiftUI+CardListItem.swift
@@ -115,9 +115,16 @@ extension OceanSwiftUI {
             self.onTouchWhenDisabled = onTouchWhenDisabled
         }
 
+        /// Onde a tag é posicionada em relação ao texto do card.
+        ///
+        /// `.leading` e `.trailing` mantêm a tag na mesma linha do título; `.above` e `.below`
+        /// a empilham dentro do bloco de conteúdo, nunca no slot do controle
+        /// (checkbox/radio/chevron).
         public enum TagPosition {
             case leading
             case trailing
+            case above
+            case below
         }
     }
 
@@ -150,6 +157,19 @@ extension OceanSwiftUI {
         private var disabledTagStatus: TagParameters.Status = .neutralInterface
         private var hasIconTrailingViews: Bool {
             parameters.trailingIcon != nil && parameters.isEnabled
+        }
+
+        private var hasTag: Bool {
+            !parameters.tagLabel.isEmpty
+        }
+
+        private var tagView: some View {
+            OceanSwiftUI.Tag { tag in
+                tag.parameters.icon = parameters.tagIcon
+                tag.parameters.label = parameters.tagLabel
+                tag.parameters.status = parameters.isEnabled ? parameters.tagStatus : disabledTagStatus
+                tag.parameters.size = parameters.tagSize
+            }
         }
 
         @ViewBuilder
@@ -218,6 +238,11 @@ extension OceanSwiftUI {
                             }
 
                             VStack(alignment: .leading, spacing: 0) {
+                                if hasTag, parameters.tagPosition == .above {
+                                    tagView
+                                        .padding(.bottom, Ocean.size.spacingStackXxs)
+                                }
+
                                 HStack(spacing: Ocean.size.spacingStackXxxs) {
                                     OceanSwiftUI.Typography.paragraph { label in
                                         label.parameters.text = parameters.title
@@ -225,13 +250,8 @@ extension OceanSwiftUI {
                                         label.parameters.lineLimit = parameters.titleLineLimit
                                     }
 
-                                    if !parameters.tagLabel.isEmpty, parameters.tagPosition == .leading {
-                                        OceanSwiftUI.Tag { tag in
-                                            tag.parameters.icon = parameters.tagIcon
-                                            tag.parameters.label = parameters.tagLabel
-                                            tag.parameters.status = parameters.isEnabled ? parameters.tagStatus : disabledTagStatus
-                                            tag.parameters.size = parameters.tagSize
-                                        }
+                                    if hasTag, parameters.tagPosition == .leading {
+                                        tagView
                                     }
                                 }
 
@@ -251,17 +271,17 @@ extension OceanSwiftUI {
                                     }
                                     .padding(.top, Ocean.size.spacingStackXxs)
                                 }
+
+                                if hasTag, parameters.tagPosition == .below {
+                                    tagView
+                                        .padding(.top, Ocean.size.spacingStackXxs)
+                                }
                             }
                             .frame(maxWidth: .infinity, alignment: .leading)
 
                             HStack(spacing: Ocean.size.spacingStackXxs) {
-                                if parameters.tagPosition == .trailing, !parameters.tagLabel.isEmpty {
-                                    OceanSwiftUI.Tag { tag in
-                                        tag.parameters.icon = parameters.tagIcon
-                                        tag.parameters.label = parameters.tagLabel
-                                        tag.parameters.status = parameters.isEnabled ? parameters.tagStatus : disabledTagStatus
-                                        tag.parameters.size = parameters.tagSize
-                                    }
+                                if hasTag, parameters.tagPosition == .trailing {
+                                    tagView
                                 }
 
                                 if let brandsParams = parameters.brands, !brandsParams.acquirers.isEmpty {

--- a/Sources/OceanComponents/ComponentsSwiftUI/CardListItem/OceanSwiftUI+CardListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/CardListItem/OceanSwiftUI+CardListItem.swift
@@ -115,10 +115,10 @@ extension OceanSwiftUI {
             self.onTouchWhenDisabled = onTouchWhenDisabled
         }
 
-        /// Onde a tag é posicionada em relação ao texto do card.
+        /// Where the tag is positioned relative to the card's text.
         ///
-        /// `.leading` e `.trailing` mantêm a tag na mesma linha do título; `.above` e `.below`
-        /// a empilham dentro do bloco de conteúdo, nunca no slot do controle
+        /// `.leading` and `.trailing` keep the tag on the same line as the title; `.above` and
+        /// `.below` stack it inside the content block, never in the control slot
         /// (checkbox/radio/chevron).
         public enum TagPosition {
             case leading


### PR DESCRIPTION
## Contexto

A tela de seleção de benefícios do PagBlu ([MR-523](https://useblu.atlassian.net/browse/MR-523)) posiciona a tag `%{installments}x sem acréscimo` **acima do título** do card. Hoje o `CardListItem` só posiciona a tag na mesma linha do título — `.leading` (antes) ou `.trailing` (depois) —, então a tela sairia com layout montado por fora do componente.

Subtarefa **MR-555** de [MR-552](https://useblu.atlassian.net/browse/MR-552). Spec: [Ledger](https://github.com/Pagnet/product-bluprints/blob/main/prd-tracking/MR-552-indicator-position/MR-552-indicator-position-ledger.md).

## O que muda

```swift
public enum TagPosition {
    case leading
    case trailing
    case above
    case below
}
```

Nos valores novos a tag deixa a linha do título e é empilhada **dentro do bloco de conteúdo**, com `Ocean.size.spacingStackXxs` (8pt) de separação. A `VStack` de conteúdo já é `alignment: .leading`, então a tag fica *hug* sem código extra. O bloco trailing segue intocado.

Aproveitei para **extrair `tagView` e `hasTag`**: o builder da Tag estava duplicado nos dois ramos e, com quatro posições, viraria quatro cópias do mesmo bloco.

## Não é breaking

- `.leading` segue sendo o default; `.leading` e `.trailing` renderizam exatamente como antes.
- O único call site do ecossistema (`blu-mobile-ios`, `SalePaymentMethodViewController.swift:127`, usa `.trailing`) **não precisa mudar** — varredura em `org:Pagnet` + `org:ocean-ds`.

> O rename de `tagPosition` para `indicatorPosition` **não** faz parte deste PR — fica no [MR-556](https://useblu.atlassian.net/browse/MR-556).

## Uma correção de projeto que veio junto

O arquivo de teste novo **não compilava**. A pasta `OceanDesignSystemTests` não está em nenhum `fileSystemSynchronizedGroups`; o único arquivo que o target compila entra por `membershipExceptions`. Sem acrescentar o novo arquivo a essa lista, o `xcodebuild` roda **"Executed 0 tests"** e ainda assim reporta `TEST SUCCEEDED` — um falso verde. O `project.pbxproj` foi ajustado; vale saber disso ao adicionar qualquer teste neste repo.

## Testes

`CardListItemTagPositionTests` — **9 casos, todos passando**. O repositório não tem infraestrutura de snapshot, então a verificação é de API e contrato de parâmetros (o padrão de `TypographyAlignmentTests`); a fidelidade visual das posições valida-se no app de showcase.

Cobrem: default `.leading` preservado · `.trailing` ainda atribuível · `.above` e `.below` via initializer e por mutação · exaustividade do enum (`switch` que deixa de compilar se alguém mexer nos casos) · construção da view nas 4 posições, incluindo com `hasRadioButton` · posição informada sem tag.

## ⚠️ Falhas pré-existentes na suíte

`TypographyAlignmentTests` está com **10 testes / 20 falhas** (`Avenir-Black` onde espera `NunitoSans-ExtraBold`). **Verifiquei que já falham no `master` limpo, sem estas mudanças** — não têm relação com este PR, mas o `xcodebuild test` sem filtro sai com `exit=65` por causa delas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ocean-ds/ocean-ios/pull/699" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->