### PR TITLE
fix(shortcut): toque no item bloqueado por opt-in e cadeado vencendo tag/badge

### DIFF
--- a/OceanDesignSystem.xcodeproj/project.pbxproj
+++ b/OceanDesignSystem.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 				OceanDesignSystemTests.swift,
 				CardListItemTagPositionTests.swift,
 				StatusListItemLeadingIconTests.swift,
+				ShortcutBlockedTests.swift,
 			);
 			target = 24C8014E2682585600744F30 /* OceanDesignSystemTests */;
 		};

--- a/OceanDesignSystem/Controllers/Components SwiftUI/ShortcutSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/ShortcutSwiftUIViewController.swift
@@ -55,7 +55,15 @@ class ShortcutSwiftUIViewController: UIViewController {
                                    badgeStatus: .warning,
                                    title: "Label",
                                    subtitle: "Lorem ipsum dolor sit amet, consectetur. Lorem ipsum dolor sit amet, consectetur.",
-                                   blocked: true)
+                                   blocked: true),
+        // Bloqueado que RESPONDE ao toque: é o item que abre a explicação do motivo.
+        OceanSwiftUI.ShortcutModel(icon: Ocean.icon.documentOutline,
+                                   badgeNumber: nil,
+                                   badgeStatus: .warning,
+                                   title: "Label tocável",
+                                   subtitle: "Lorem ipsum dolor sit amet, consectetur. Lorem ipsum dolor sit amet, consectetur.",
+                                   blocked: true,
+                                   forceEnableActionWhenBlocked: true)
     ]
 
     lazy var shortcut1: OceanSwiftUI.Shortcut = {

--- a/OceanDesignSystem/Controllers/Components SwiftUI/ShortcutSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/ShortcutSwiftUIViewController.swift
@@ -42,6 +42,19 @@ class ShortcutSwiftUIViewController: UIViewController {
                                    badgeStatus: .warning,
                                    title: "Label",
                                    subtitle: "Lorem ipsum dolor sit amet, consectetur. Lorem ipsum dolor sit amet, consectetur.",
+                                   blocked: true),
+        OceanSwiftUI.ShortcutModel(icon: Ocean.icon.documentOutline,
+                                   badgeNumber: nil,
+                                   badgeStatus: .warning,
+                                   tagLabel: "Oferta",
+                                   title: "Label",
+                                   subtitle: "Lorem ipsum dolor sit amet, consectetur. Lorem ipsum dolor sit amet, consectetur.",
+                                   blocked: true),
+        OceanSwiftUI.ShortcutModel(icon: Ocean.icon.documentOutline,
+                                   badgeNumber: 2,
+                                   badgeStatus: .warning,
+                                   title: "Label",
+                                   subtitle: "Lorem ipsum dolor sit amet, consectetur. Lorem ipsum dolor sit amet, consectetur.",
                                    blocked: true)
     ]
 

--- a/OceanDesignSystemTests/ShortcutBlockedTests.swift
+++ b/OceanDesignSystemTests/ShortcutBlockedTests.swift
@@ -10,11 +10,13 @@ import SwiftUI
 import OceanTokens
 @testable import OceanComponents
 
-/// Covers the `blocked` contract of the Shortcut SwiftUI component: it shows the lock and keeps
-/// the item tappable, because the tap is what explains why the function is restricted.
+/// Covers the `blocked` contract of the Shortcut SwiftUI component: it shows the lock, keeps the
+/// item disabled by default (backwards compatibility) and becomes tappable only with
+/// `forceEnableActionWhenBlocked` — the case where the tap is what explains the restriction.
 ///
 /// The repository has no snapshot infrastructure, so the checks here are on the API and the
-/// parameter contract; the gesture itself is validated in the showcase app.
+/// parameter contract; `isActionDisabled` is the single source the view reads, which is why the
+/// truth table below is the real regression guard. The gesture is validated in the showcase app.
 final class ShortcutBlockedTests: XCTestCase {
 
     // MARK: - Default
@@ -43,11 +45,44 @@ final class ShortcutBlockedTests: XCTestCase {
 
     // MARK: - Interaction
 
-    /// `onTouch` segue sendo o caminho do item bloqueado: sem isto o cadeado seria um beco sem
-    /// saída, e é justamente ele que precisa abrir a explicação do motivo.
+    /// Tabela-verdade do `.disabled` da view. O default preserva o comportamento de sempre —
+    /// bloqueado não clica — e a chave explícita é o que libera o toque.
+    func testIsActionDisabledTruthTable() {
+        let free = OceanSwiftUI.ShortcutModel(title: "Extrato")
+        let blocked = OceanSwiftUI.ShortcutModel(title: "Antecipar vendas", blocked: true)
+        let blockedTappable = OceanSwiftUI.ShortcutModel(title: "Antecipar vendas",
+                                                        blocked: true,
+                                                        forceEnableActionWhenBlocked: true)
+        let freeWithFlag = OceanSwiftUI.ShortcutModel(title: "Extrato",
+                                                      forceEnableActionWhenBlocked: true)
+
+        XCTAssertFalse(free.isActionDisabled)
+        XCTAssertTrue(blocked.isActionDisabled)
+        XCTAssertFalse(blockedTappable.isActionDisabled)
+        XCTAssertFalse(freeWithFlag.isActionDisabled)
+    }
+
+    func testForceEnableActionWhenBlockedIsFalseByDefault() {
+        let item = OceanSwiftUI.ShortcutModel(title: "Title", blocked: true)
+
+        XCTAssertFalse(item.forceEnableActionWhenBlocked)
+        XCTAssertTrue(item.isActionDisabled)
+    }
+
+    func testForceEnableActionWhenBlockedIsAssignableViaProperty() {
+        let item = OceanSwiftUI.ShortcutModel(title: "Title", blocked: true)
+
+        item.forceEnableActionWhenBlocked = true
+
+        XCTAssertFalse(item.isActionDisabled)
+    }
+
+    /// `onTouch` é o caminho do item restrito que fala: é por ele que a tela abre a explicação.
     func testOnTouchIsDeliveredForABlockedItem() {
         let expectation = expectation(description: "onTouch called for a blocked item")
-        let blockedItem = OceanSwiftUI.ShortcutModel(title: "Antecipar vendas", blocked: true)
+        let blockedItem = OceanSwiftUI.ShortcutModel(title: "Antecipar vendas",
+                                                     blocked: true,
+                                                     forceEnableActionWhenBlocked: true)
         let parameters = OceanSwiftUI.ShortcutParameters(items: [blockedItem]) { index, item in
             XCTAssertEqual(index, 0)
             XCTAssertTrue(item.blocked)

--- a/OceanDesignSystemTests/ShortcutBlockedTests.swift
+++ b/OceanDesignSystemTests/ShortcutBlockedTests.swift
@@ -59,6 +59,22 @@ final class ShortcutBlockedTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
+    // MARK: - Corner slot
+
+    /// Cadeado, tag e badge dividem o mesmo canto. O contrato é o do Ocean web: com `blocked`
+    /// o cadeado vence, e tag/badge continuam no model sem serem desenhados — o item pode voltar
+    /// a mostrá-los assim que a função for liberada, sem o consumidor remontar nada.
+    func testBlockedItemKeepsTagAndBadgeInTheModel() {
+        let item = OceanSwiftUI.ShortcutModel(badgeNumber: 2,
+                                              tagLabel: "Oferta",
+                                              title: "Antecipar vendas",
+                                              blocked: true)
+
+        XCTAssertTrue(item.blocked)
+        XCTAssertEqual(item.tagLabel, "Oferta")
+        XCTAssertEqual(item.badgeNumber, 2)
+    }
+
     func testBlockedItemsCoexistWithUnblockedOnesInTheSameList() {
         let parameters = OceanSwiftUI.ShortcutParameters(items: [
             .init(title: "Extrato"),

--- a/OceanDesignSystemTests/ShortcutBlockedTests.swift
+++ b/OceanDesignSystemTests/ShortcutBlockedTests.swift
@@ -1,0 +1,71 @@
+//
+//  ShortcutBlockedTests.swift
+//  OceanDesignSystemTests
+//
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+import OceanTokens
+@testable import OceanComponents
+
+/// Covers the `blocked` contract of the Shortcut SwiftUI component: it shows the lock and keeps
+/// the item tappable, because the tap is what explains why the function is restricted.
+///
+/// The repository has no snapshot infrastructure, so the checks here are on the API and the
+/// parameter contract; the gesture itself is validated in the showcase app.
+final class ShortcutBlockedTests: XCTestCase {
+
+    // MARK: - Default
+
+    func testBlockedIsFalseByDefault() {
+        let item = OceanSwiftUI.ShortcutModel(title: "Title")
+
+        XCTAssertFalse(item.blocked)
+    }
+
+    // MARK: - Assignment
+
+    func testBlockedIsAssignableViaInitializer() {
+        let item = OceanSwiftUI.ShortcutModel(title: "Title", blocked: true)
+
+        XCTAssertTrue(item.blocked)
+    }
+
+    func testBlockedIsAssignableViaProperty() {
+        let item = OceanSwiftUI.ShortcutModel(title: "Title")
+
+        item.blocked = true
+
+        XCTAssertTrue(item.blocked)
+    }
+
+    // MARK: - Interaction
+
+    /// `onTouch` segue sendo o caminho do item bloqueado: sem isto o cadeado seria um beco sem
+    /// saída, e é justamente ele que precisa abrir a explicação do motivo.
+    func testOnTouchIsDeliveredForABlockedItem() {
+        let expectation = expectation(description: "onTouch called for a blocked item")
+        let blockedItem = OceanSwiftUI.ShortcutModel(title: "Antecipar vendas", blocked: true)
+        let parameters = OceanSwiftUI.ShortcutParameters(items: [blockedItem]) { index, item in
+            XCTAssertEqual(index, 0)
+            XCTAssertTrue(item.blocked)
+            expectation.fulfill()
+        }
+
+        parameters.onTouch(0, blockedItem)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testBlockedItemsCoexistWithUnblockedOnesInTheSameList() {
+        let parameters = OceanSwiftUI.ShortcutParameters(items: [
+            .init(title: "Extrato"),
+            .init(title: "Antecipar vendas", blocked: true)
+        ])
+
+        XCTAssertFalse(parameters.items[0].blocked)
+        XCTAssertTrue(parameters.items[1].blocked)
+    }
+}

--- a/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
@@ -278,9 +278,23 @@ extension OceanSwiftUI {
             }
         }
 
+        /// Cadeado, tag e badge dividem o mesmo canto — um único slot. Com a função restrita o
+        /// cadeado vem primeiro: ele é o que explica o estado do item, enquanto tag e badge falam
+        /// de oferta e de contagem, que não servem para nada se a função não abre. É a mesma
+        /// precedência do Ocean web, onde `blocked` suprime tag e badge.
         @ViewBuilder
         private func getOverlay(item: ShortcutModel) -> some View {
-            if let tagLabel = item.tagLabel, parameters.size != .tiny || parameters.orientation != .horizontal {
+            if item.blocked {
+                Image(uiImage: Ocean.icon.lockClosedSolid)
+                    .resizable()
+                    .renderingMode(.template)
+                    .frame(width: 16,
+                           height: 16,
+                           alignment: .center)
+                    .foregroundColor(Color(Ocean.color.colorInterfaceDarkUp))
+                    .padding(.top, Ocean.size.spacingStackXxs)
+                    .padding(.trailing, Ocean.size.spacingStackXxs)
+            } else if let tagLabel = item.tagLabel, parameters.size != .tiny || parameters.orientation != .horizontal {
                 OceanSwiftUI.Tag { view in
                     view.parameters.label = tagLabel
                     view.parameters.status = item.tagStatus
@@ -296,16 +310,6 @@ extension OceanSwiftUI {
                 }
                 .padding(.top, Ocean.size.spacingStackXxs)
                 .padding(.trailing, Ocean.size.spacingStackXxs)
-            } else if item.blocked {
-                Image(uiImage: Ocean.icon.lockClosedSolid)
-                    .resizable()
-                    .renderingMode(.template)
-                    .frame(width: 16,
-                           height: 16,
-                           alignment: .center)
-                    .foregroundColor(Color(Ocean.color.colorInterfaceDarkUp))
-                    .padding(.top, Ocean.size.spacingStackXxs)
-                    .padding(.trailing, Ocean.size.spacingStackXxs)
             }
         }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
@@ -60,12 +60,19 @@ extension OceanSwiftUI {
         @Published public var title: String
         @Published public var subtitle: String
 
-        /// Função restrita: mostra o cadeado e **mantém o item tocável**.
+        /// Função restrita: mostra o cadeado e, por retrocompatibilidade, **continua sem toque**.
         ///
-        /// O toque é o que resta ao cliente quando a função está indisponível — é por ele que a
-        /// tela explica o motivo. Um item com cadeado e sem toque é um beco sem saída, então
-        /// `blocked` NÃO desliga a interação; quem precisa de item inerte não passa `onTouch`.
+        /// Para o item restrito responder ao toque — o caso em que o toque é o que explica a
+        /// restrição — ligue `forceEnableActionWhenBlocked`.
         @Published public var blocked: Bool
+
+        /// Deixa o item tocável mesmo com `blocked`. Nasce `false`, então nada muda para quem já usa
+        /// o componente.
+        ///
+        /// Ligue quando o toque for a resposta ao cadeado: um item que avisa que a função está
+        /// restrita e não deixa o cliente descobrir por quê é um beco sem saída. Item que não tem o
+        /// que dizer continua inerte com o default.
+        @Published public var forceEnableActionWhenBlocked: Bool
 
         public init(icon: UIImage? = nil,
                     badgeNumber: Int? = nil,
@@ -74,7 +81,8 @@ extension OceanSwiftUI {
                     tagStatus: TagParameters.Status = .highlightImportant,
                     title: String,
                     subtitle: String = "",
-                    blocked: Bool = false) {
+                    blocked: Bool = false,
+                    forceEnableActionWhenBlocked: Bool = false) {
             self.icon = icon
             self.badgeNumber = badgeNumber
             self.badgeStatus = badgeStatus
@@ -83,6 +91,12 @@ extension OceanSwiftUI {
             self.title = title
             self.subtitle = subtitle
             self.blocked = blocked
+            self.forceEnableActionWhenBlocked = forceEnableActionWhenBlocked
+        }
+
+        /// Única fonte da decisão de interação do item — o `.disabled` da view lê daqui.
+        var isActionDisabled: Bool {
+            blocked && !forceEnableActionWhenBlocked
         }
     }
 
@@ -132,6 +146,7 @@ extension OceanSwiftUI {
                                     getContentView(item: item)
                                 })
                                 .buttonStyle(OceanShortcutStyle())
+                                .disabled(item.isActionDisabled)
                             }
                         }
                     }
@@ -150,6 +165,7 @@ extension OceanSwiftUI {
                                         getContentView(item: item)
                                     })
                                     .buttonStyle(OceanShortcutStyle())
+                                    .disabled(item.isActionDisabled)
                                     .layoutPriority(1.0)
                                 }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/Shortcut/OceanSwiftUI+Shortcut.swift
@@ -59,6 +59,12 @@ extension OceanSwiftUI {
         @Published public var tagStatus: TagParameters.Status
         @Published public var title: String
         @Published public var subtitle: String
+
+        /// Função restrita: mostra o cadeado e **mantém o item tocável**.
+        ///
+        /// O toque é o que resta ao cliente quando a função está indisponível — é por ele que a
+        /// tela explica o motivo. Um item com cadeado e sem toque é um beco sem saída, então
+        /// `blocked` NÃO desliga a interação; quem precisa de item inerte não passa `onTouch`.
         @Published public var blocked: Bool
 
         public init(icon: UIImage? = nil,
@@ -126,7 +132,6 @@ extension OceanSwiftUI {
                                     getContentView(item: item)
                                 })
                                 .buttonStyle(OceanShortcutStyle())
-                                .disabled(item.blocked)
                             }
                         }
                     }
@@ -145,7 +150,6 @@ extension OceanSwiftUI {
                                         getContentView(item: item)
                                     })
                                     .buttonStyle(OceanShortcutStyle())
-                                    .disabled(item.blocked)
                                     .layoutPriority(1.0)
                                 }
 


### PR DESCRIPTION
Duas correções no `Shortcut` SwiftUI, as duas sobre o mesmo estado — `blocked` — e as duas alinhando o iOS ao Ocean web.

## 1. Item bloqueado não aceitava o toque

O `blocked` desenhava o cadeado **e** aplicava `.disabled(item.blocked)` no `SwiftUI.Button` (nos dois `displayMode`). O item então avisa que a função está restrita e não deixa o cliente descobrir por quê — o `onTouch` nunca chega ao consumidor.

Foi assim que apareceu: na home do app da Blu o atalho restrito precisa abrir uma modal explicando o motivo (título, descrição e um botão que o backend resolve). Com o cadeado o toque morre; sem o cadeado o toque funciona, mas o item fica igual a um liberado. Hoje não há como ter os dois.

Cadeado e interação são coisas diferentes. `blocked` responde por "esta função está indisponível", e o toque é o que abre a explicação.

**Depois da revisão do @acassiovilasboas, isso virou opt-in explícito:** `forceEnableActionWhenBlocked` nasce `false`, então `blocked` continua exatamente como era — cadeado e sem toque — e quem precisa do toque liga a chave no item. A decisão de interação vive num lugar só, `isActionDisabled` = `blocked && !forceEnableActionWhenBlocked`, que é o que a view lê no `.disabled` dos dois `displayMode`.

## 2. Cadeado, tag e badge dividem o mesmo canto — e o cadeado ficava por último

O `else if` do overlay era tag → badge → cadeado. Item restrito com tag ("Oferta") ou com contador saía **sem cadeado nenhum**, visualmente igual a um liberado.

A precedência agora é a do web (`!blocked && (count || badge)` e `!blocked && tag`): com a função restrita o cadeado vem primeiro. Tag e badge continuam no model, só não são desenhados — o item volta a mostrá-los quando a função for liberada, sem o consumidor remontar nada.

## O que entrou

- `forceEnableActionWhenBlocked` (default `false`) no `ShortcutModel`, e `isActionDisabled` como fonte única do `.disabled` nos dois `displayMode`;
- `getOverlay` reordenado: `blocked` → tag → badge;
- `blocked` documentado no `ShortcutModel` com o contrato;
- `ShortcutBlockedTests`: tabela-verdade de `isActionDisabled`, default da chave, atribuição, `onTouch` entregue para o item bloqueado com a chave ligada e o contrato do canto (tag/badge preservados no model);
- showcase com três exemplos novos — bloqueado com tag, bloqueado com badge e bloqueado **com a chave ligada** — para dar para ver a precedência e a diferença de toque na tela.

## Impacto nos consumidores

**Sem mudança de comportamento por default.** Item com `blocked = true` continua sem entregar `onTouch`; só entrega quando o consumidor liga `forceEnableActionWhenBlocked`. A única mudança que vale para todo mundo é visual: com `blocked`, o canto passa a ser do cadeado, e tag/badge não são desenhados ali.

## Paridade

Mesmas duas correções no Ocean Android: ocean-ds/ocean-android#1106. Contrato final nas duas plataformas — `blocked` = cadeado que aceita toque e manda no canto; `disabled` (Android) = inerte.

## Como validar

Showcase → Shortcut (SwiftUI): os quatro últimos itens de cada lista são `blocked` e todos mostram o cadeado (inclusive o que tem tag e o que tem badge). Só o último tem `forceEnableActionWhenBlocked` — o toque nele imprime índice e título no console, e nos outros três não acontece nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
