### PR TITLE
fix(inline-text-list-item): lay the item row out as a two-column grid

### DIFF
--- a/OceanDesignSystem.xcodeproj/project.pbxproj
+++ b/OceanDesignSystem.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 				StatusListItemLeadingIconTests.swift,
 				ShortcutBlockedTests.swift,
 				InlineTextListItemGridTests.swift,
+				TransactionFooterSpacingTests.swift,
 			);
 			target = 24C8014E2682585600744F30 /* OceanDesignSystemTests */;
 		};

--- a/OceanDesignSystem.xcodeproj/project.pbxproj
+++ b/OceanDesignSystem.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 				CardListItemTagPositionTests.swift,
 				StatusListItemLeadingIconTests.swift,
 				ShortcutBlockedTests.swift,
+				InlineTextListItemGridTests.swift,
 			);
 			target = 24C8014E2682585600744F30 /* OceanDesignSystemTests */;
 		};

--- a/OceanDesignSystem/Controllers/Components SwiftUI/InlineTextListItemSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/InlineTextListItemSwiftUIViewController.swift
@@ -582,6 +582,77 @@ class InlineTextListItemSwiftUIViewController: UIViewController {
         }
     }()
 
+    lazy var inlineTextListItemGridShortShort: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Pague em",
+            value: "3x de R$ 116,67"
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+        }
+    }()
+
+    lazy var inlineTextListItemGridShortLong: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Pague em",
+            value: "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo"
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+        }
+    }()
+
+    lazy var inlineTextListItemGridLongLong: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Economia com antecipação grátis",
+            value: "Valor economizado em antecipação"
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+        }
+    }()
+
+    lazy var inlineTextListItemGridLongShort: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Total a pagar com acréscimo em até 6 vezes",
+            value: "R$ 577,98",
+            isBoldValue: true
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+        }
+    }()
+
+    lazy var inlineTextListItemGridStrikethrough: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Economia com antecipação grátis",
+            value: "R$ 350,00",
+            newValue: "R$ 320,00"
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+        }
+    }()
+
+    lazy var inlineTextListItemGridWithTag: OceanSwiftUI.InlineTextListItem = {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Recebimentos futuros da semana",
+            value: "R$ 2.300,00"
+        )
+
+        return OceanSwiftUI.InlineTextListItem { textListItem in
+            textListItem.parameters.item = item
+            textListItem.parameters.tag = .init(label: "Oferta",
+                                                icon: Ocean.icon.fireOutline!,
+                                                status: .warning)
+        }
+    }()
+
     public lazy var hostingController = UIHostingController(rootView: ScrollView {
         VStack(spacing: Ocean.size.spacingStackXs) {
             inlineTextListItem0
@@ -631,6 +702,19 @@ class InlineTextListItemSwiftUIViewController: UIViewController {
             inlineTextListItem17Direct
             inlineTextListItem18Direct
             inlineTextListItem19Direct
+        }
+
+        VStack(spacing: Ocean.size.spacingStackXs) {
+            OceanSwiftUI.Typography.heading1 { label in
+                label.parameters.text = "Grid de duas colunas"
+            }
+
+            inlineTextListItemGridShortShort
+            inlineTextListItemGridShortLong
+            inlineTextListItemGridLongLong
+            inlineTextListItemGridLongShort
+            inlineTextListItemGridStrikethrough
+            inlineTextListItemGridWithTag
         }
     })
 

--- a/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
+++ b/OceanDesignSystem/Controllers/Components SwiftUI/TransactionFooterSwiftUIViewController.swift
@@ -18,7 +18,6 @@ class TransactionFooterSwiftUIViewController: UIViewController {
         view.parameters.buttonOrientation = .vertical
         view.parameters.skeletonLines = 4
         view.parameters.showSkeleton = true
-        view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
                                         leading: Ocean.size.spacingStackXs,
                                         bottom: Ocean.size.spacingStackXs,
@@ -42,7 +41,6 @@ class TransactionFooterSwiftUIViewController: UIViewController {
     private lazy var transactionFooterWithCaption = OceanSwiftUI.TransactionFooter { view in
         view.parameters.primaryButton = .init(text: "Agendar", style: .primary, onTouch: { print("Agendar") })
         view.parameters.buttonOrientation = .vertical
-        view.parameters.interlineSpacing = Ocean.size.spacingStackXxs
         view.parameters.padding = .init(top: Ocean.size.spacingStackXs,
                                         leading: Ocean.size.spacingStackXs,
                                         bottom: Ocean.size.spacingStackXs,

--- a/OceanDesignSystemTests/InlineTextListItemGridTests.swift
+++ b/OceanDesignSystemTests/InlineTextListItemGridTests.swift
@@ -1,0 +1,203 @@
+//
+//  InlineTextListItemGridTests.swift
+//  OceanDesignSystemTests
+//
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+import OceanTokens
+@testable import OceanComponents
+
+/// Covers the `item`-based render branch of `InlineTextListItem` (MR-732 / QA-07): the row is a
+/// two-column grid where both columns share the available width equally and each side wraps
+/// inside its own column, so neither text grows into the other one.
+///
+/// The repository has no snapshot infrastructure, so the checks here are on the API and the
+/// parameter contract; the visual result is validated in the showcase app.
+final class InlineTextListItemGridTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    private func makeItem(text: String = "Pague em",
+                          value: String = "3x de R$ 116,67 sem acréscimo",
+                          isBoldValue: Bool = false,
+                          newValue: String = "") -> OceanSwiftUI.InlineTextListItemParameters.ItemModel {
+        .init(text: text,
+              value: value,
+              isBoldValue: isBoldValue,
+              newValue: newValue)
+    }
+
+    // MARK: - The item branch is the one under test
+
+    func testViewUsesTheItemBranchWhenItemIsSet() {
+        let item = makeItem()
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertNotNil(view.parameters.item)
+        XCTAssertEqual(view.parameters.item?.text, "Pague em")
+        XCTAssertEqual(view.parameters.item?.value, "3x de R$ 116,67 sem acréscimo")
+    }
+
+    func testViewFallsBackToTheTitleBranchWhenItemIsNil() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.title = "Pague em"
+            component.parameters.description = "3x de R$ 116,67"
+        }
+
+        XCTAssertNil(view.parameters.item)
+        XCTAssertEqual(view.parameters.title, "Pague em")
+    }
+
+    // MARK: - Grid variations (the QA-07 defect)
+
+    func testViewIsBuiltWithALongValueThatHasToWrap() {
+        let item = makeItem(value: "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo")
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertEqual(view.parameters.item?.value,
+                       "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo")
+        XCTAssertTrue(view.parameters.item?.text.isEmpty == false)
+    }
+
+    func testViewIsBuiltWithALongLabelAndALongValue() {
+        let item = makeItem(text: "Total a pagar com acréscimo",
+                            value: "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo")
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertEqual(view.parameters.item?.text, "Total a pagar com acréscimo")
+    }
+
+    func testViewIsBuiltWithBothColumnsLong() {
+        let item = makeItem(text: "Economia com antecipação grátis",
+                            value: "Valor economizado em antecipação")
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertEqual(view.parameters.item?.text, "Economia com antecipação grátis")
+        XCTAssertEqual(view.parameters.item?.value, "Valor economizado em antecipação")
+    }
+
+    // MARK: - Non-regression of the other item combinations
+
+    func testViewIsBuiltWithBoldValue() {
+        let item = makeItem(value: "R$ 350,00", isBoldValue: true)
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertEqual(view.parameters.item?.isBoldValue, true)
+    }
+
+    func testViewIsBuiltWithStrikethroughAndNewValue() {
+        let item = makeItem(value: "R$ 350,00", newValue: "R$ 320,00")
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertEqual(view.parameters.item?.value, "R$ 350,00")
+        XCTAssertEqual(view.parameters.item?.newValue, "R$ 320,00")
+    }
+
+    func testViewIsBuiltWithImageIcon() {
+        let item = OceanSwiftUI.InlineTextListItemParameters.ItemModel(
+            text: "Pague em",
+            value: "3x de R$ 116,67",
+            imageIcon: UIImage(),
+            imageColor: Ocean.color.colorStatusPositiveDeep
+        )
+
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = item
+        }
+
+        XCTAssertNotNil(view.parameters.item?.imageIcon)
+    }
+
+    func testViewIsBuiltWithTagAlongsideTheItem() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem()
+            component.parameters.tag = OceanSwiftUI.TagParameters(label: "sem acréscimo")
+        }
+
+        XCTAssertNotNil(view.parameters.tag)
+        XCTAssertNotNil(view.parameters.item)
+    }
+
+    func testViewIsBuiltWithRoundedIconAlongsideTheItem() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem()
+            component.parameters.icon = OceanSwiftUI.RoundedIconParameters()
+        }
+
+        XCTAssertNotNil(view.parameters.icon)
+    }
+
+    func testViewIsBuiltWithButtonAlongsideTheItem() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem()
+            component.parameters.button = OceanSwiftUI.ButtonParameters(text: "Ver mais")
+        }
+
+        XCTAssertNotNil(view.parameters.button)
+    }
+
+    func testViewIsBuiltWithEmptyValue() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(value: "")
+        }
+
+        XCTAssertEqual(view.parameters.item?.value, "")
+    }
+
+    // MARK: - Skeleton keeps precedence over both branches
+
+    func testSkeletonTakesPrecedenceOverTheItemBranch() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem()
+            component.parameters.showSkeleton = true
+        }
+
+        XCTAssertTrue(view.parameters.showSkeleton)
+        XCTAssertNotNil(view.parameters.item)
+    }
+
+    // MARK: - Padding contract consumed by the app
+
+    func testDefaultPaddingIsVerticalOnly() {
+        let parameters = OceanSwiftUI.InlineTextListItemParameters()
+
+        XCTAssertEqual(parameters.padding.leading, 0)
+        XCTAssertEqual(parameters.padding.trailing, 0)
+        XCTAssertEqual(parameters.padding.top, Ocean.size.spacingStackXxs)
+        XCTAssertEqual(parameters.padding.bottom, Ocean.size.spacingStackXxs)
+    }
+
+    func testPaddingIsOverridableByTheConsumer() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem()
+            component.parameters.padding = .init(top: Ocean.size.spacingStackXxs,
+                                                 leading: Ocean.size.spacingStackXs,
+                                                 bottom: Ocean.size.spacingStackXxs,
+                                                 trailing: Ocean.size.spacingStackXs)
+        }
+
+        XCTAssertEqual(view.parameters.padding.leading, Ocean.size.spacingStackXs)
+        XCTAssertEqual(view.parameters.padding.trailing, Ocean.size.spacingStackXs)
+    }
+}

--- a/OceanDesignSystemTests/InlineTextListItemGridTests.swift
+++ b/OceanDesignSystemTests/InlineTextListItemGridTests.swift
@@ -177,6 +177,76 @@ final class InlineTextListItemGridTests: XCTestCase {
         XCTAssertNotNil(view.parameters.item)
     }
 
+    // MARK: - Layout (measured — these fail without the grid)
+
+    /// Width of a compact phone content area (iPhone SE class) — narrow enough that a long
+    /// text has to wrap in a 50% column but not in a full-width space-between row.
+    private let narrowWidth: CGFloat = 320
+
+    private func measuredHeight<V: View>(_ view: V, width: CGFloat) -> CGFloat {
+        let host = UIHostingController(rootView: view)
+        host.view.setNeedsLayout()
+        host.view.layoutIfNeeded()
+        return host.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
+    }
+
+    private func singleLineRowHeight() -> CGFloat {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: "A", value: "B")
+        }
+        return measuredHeight(view, width: narrowWidth)
+    }
+
+    /// Long label / short value: in the old space-between layout the label kept its ideal
+    /// width and the row stayed on one line; in the grid the label is confined to half the
+    /// width and wraps, so the row gets taller. Guards the grid itself.
+    func testLongLabelWrapsInsideItsColumn() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: "Total a pagar com acréscimo em até 6 vezes",
+                                                      value: "R$ 577,98")
+        }
+
+        XCTAssertGreaterThan(measuredHeight(view, width: narrowWidth), singleLineRowHeight() * 1.5)
+    }
+
+    /// Short label / long value: the value wraps inside the right column instead of
+    /// pushing into the label's.
+    func testLongValueWrapsInsideItsColumn() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: "Pague em",
+                                                      value: "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo")
+        }
+
+        XCTAssertGreaterThan(measuredHeight(view, width: narrowWidth), singleLineRowHeight() * 1.5)
+    }
+
+    /// Tag + rounded icon next to a short value must NOT be squeezed by the 50% column: the
+    /// adornments keep their intrinsic size, so the row stays on one line. This is the case
+    /// that broke in the first version of the grid (tag wrapping mid-word).
+    func testTagAndRoundedIconKeepTheRowOnOneLine() {
+        let view = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: "Title", value: "R$ 90")
+            component.parameters.tag = OceanSwiftUI.TagParameters(label: "Oferta")
+            component.parameters.icon = OceanSwiftUI.RoundedIconParameters()
+        }
+
+        // RoundedIcon is 40pt tall, so a healthy row is icon-height, not a multi-line text block.
+        XCTAssertLessThan(measuredHeight(view, width: narrowWidth), 40 + Ocean.size.spacingStackXxs * 2 + 8)
+    }
+
+    /// Same grid inside `TransactionFooter`, which renders its own `ItemModel`: a long value
+    /// wraps in its column there too.
+    func testTransactionFooterItemWrapsLongValue() {
+        let short = OceanSwiftUI.TransactionFooter { footer in
+            footer.parameters.items = [.init(text: "Pague em", value: "3x de R$ 116,67")]
+        }
+        let long = OceanSwiftUI.TransactionFooter { footer in
+            footer.parameters.items = [.init(text: "Pague em", value: "6x de R$ 96,33 com a 1ª e a 2ª sem acréscimo")]
+        }
+
+        XCTAssertGreaterThan(measuredHeight(long, width: narrowWidth), measuredHeight(short, width: narrowWidth) + 10)
+    }
+
     // MARK: - Padding contract consumed by the app
 
     func testDefaultPaddingIsVerticalOnly() {

--- a/OceanDesignSystemTests/InlineTextListItemGridTests.swift
+++ b/OceanDesignSystemTests/InlineTextListItemGridTests.swift
@@ -234,6 +234,25 @@ final class InlineTextListItemGridTests: XCTestCase {
         XCTAssertLessThan(measuredHeight(view, width: narrowWidth), 40 + Ocean.size.spacingStackXxs * 2 + 8)
     }
 
+    /// The same long label wraps in the grid (text-only row) but not when a rounded icon
+    /// switches the row to the legacy space-between layout — the adornment must never make
+    /// the texts wrap per character.
+    func testWideAdornmentFallsBackToLegacyLayout() {
+        let text = "Total a pagar com acréscimo em até 6 vezes"
+        let grid = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: text, value: "R$ 577,98")
+        }
+        let legacy = OceanSwiftUI.InlineTextListItem { component in
+            component.parameters.item = self.makeItem(text: text, value: "R$ 577,98")
+            component.parameters.icon = OceanSwiftUI.RoundedIconParameters()
+        }
+
+        XCTAssertGreaterThan(measuredHeight(grid, width: narrowWidth), singleLineRowHeight() * 1.5)
+        // Legacy row: label keeps its ideal width and may wrap once, but the row is bounded by
+        // a single wrapped label next to a 40pt icon — never a per-character value stack.
+        XCTAssertLessThan(measuredHeight(legacy, width: narrowWidth), singleLineRowHeight() * 3)
+    }
+
     /// Same grid inside `TransactionFooter`, which renders its own `ItemModel`: a long value
     /// wraps in its column there too.
     func testTransactionFooterItemWrapsLongValue() {

--- a/OceanDesignSystemTests/TransactionFooterSpacingTests.swift
+++ b/OceanDesignSystemTests/TransactionFooterSpacingTests.swift
@@ -1,0 +1,79 @@
+//
+//  TransactionFooterSpacingTests.swift
+//  OceanDesignSystemTests
+//
+//  Copyright © 2026 Blu Pagamentos. All rights reserved.
+//
+
+import XCTest
+import SwiftUI
+import OceanTokens
+@testable import OceanComponents
+
+/// Vertical rhythm of `TransactionFooter` against the Figma component (MR-732 / QA-08):
+/// every row is an Inline Text List Item with `spacingStackXxs` of vertical padding, rows have
+/// no extra gap between them, the button bar sits `spacingStackXs` below the last row and a
+/// footer without rows must not pay that gap (it used to render an empty rows block plus the
+/// stack spacing, doubling the space above the button).
+final class TransactionFooterSpacingTests: XCTestCase {
+
+    private let width: CGFloat = 320
+
+    // MARK: - Helpers
+
+    private func measuredHeight<V: View>(_ view: V) -> CGFloat {
+        let controller = UIHostingController(rootView: view)
+        controller.view.frame = CGRect(x: 0, y: 0, width: width, height: 1000)
+        controller.view.layoutIfNeeded()
+        return controller.sizeThatFits(in: CGSize(width: width, height: .greatestFiniteMagnitude)).height
+    }
+
+    private func footer(rows: Int) -> OceanSwiftUI.TransactionFooter {
+        OceanSwiftUI.TransactionFooter { view in
+            view.parameters.primaryButton = .init(text: "Escolher parcelas", style: .primary, onTouch: {})
+            view.parameters.padding = .init()
+            view.parameters.items = (0..<rows).map { index in
+                .init(text: "Linha \(index)", value: "R$ 100,00")
+            }
+        }
+    }
+
+    private func bareRow() -> some View {
+        OceanSwiftUI.LabelValueGridRow(text: "Linha 0",
+                          value: "R$ 100,00",
+                          valueColor: Ocean.color.colorInterfaceDarkDeep,
+                          isBoldValue: false,
+                          newValue: "",
+                          newValueColor: Ocean.color.colorStatusPositiveDeep,
+                          imageIcon: nil as UIImage?,
+                          imageColor: Ocean.color.colorStatusPositiveDeep)
+    }
+
+    // MARK: - Tests
+
+    func testDefaultInterlineSpacingIsZeroBecauseRowsCarryTheirOwnPadding() {
+        XCTAssertEqual(OceanSwiftUI.TransactionFooterParameters().interlineSpacing, 0)
+    }
+
+    func testFooterWithoutRowsHasNoGapAboveTheButton() {
+        let button = measuredHeight(OceanSwiftUI.Button { view in
+            view.parameters.text = "Escolher parcelas"
+            view.parameters.style = .primary
+        })
+
+        XCTAssertEqual(measuredHeight(footer(rows: 0)), button, accuracy: 0.5,
+                       "an empty rows block must not add the stack spacing above the button")
+    }
+
+    func testEachRowAddsItsTextPlusTheInlineTextListItemPadding() {
+        let noRows = measuredHeight(footer(rows: 0))
+        let oneRow = measuredHeight(footer(rows: 1))
+        let twoRows = measuredHeight(footer(rows: 2))
+        let rowHeight = twoRows - oneRow
+
+        XCTAssertEqual(rowHeight, measuredHeight(bareRow()) + 2 * Ocean.size.spacingStackXxs, accuracy: 0.5,
+                       "rows are spaced only by their own spacingStackXxs vertical padding")
+        XCTAssertEqual(oneRow - noRows, rowHeight + Ocean.size.spacingStackXs, accuracy: 0.5,
+                       "the first row also brings the spacingStackXs gap between rows and button")
+    }
+}

--- a/OceanDesignSystemTests/TransactionFooterSpacingTests.swift
+++ b/OceanDesignSystemTests/TransactionFooterSpacingTests.swift
@@ -30,7 +30,8 @@ final class TransactionFooterSpacingTests: XCTestCase {
 
     private func footer(rows: Int) -> OceanSwiftUI.TransactionFooter {
         OceanSwiftUI.TransactionFooter { view in
-            view.parameters.primaryButton = .init(text: "Escolher parcelas", style: .primary, onTouch: {})
+            // The action is irrelevant here: only the button's footprint is measured.
+            view.parameters.primaryButton = .init(text: "Escolher parcelas", style: .primary, onTouch: { /* no-op */ })
             view.parameters.padding = .init()
             view.parameters.items = (0..<rows).map { index in
                 .init(text: "Linha \(index)", value: "R$ 100,00")

--- a/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
@@ -215,71 +215,74 @@ extension OceanSwiftUI {
             }
         }
 
-        /// Renders a label/value row as a two-column grid.
+        /// Renders a label/value row.
         ///
-        /// Both columns are flexible and share the available width equally, separated by a
-        /// gap, so each side wraps inside its own column and neither grows into the other.
-        /// The label is leading-aligned, the value side trailing-aligned, and the column that
-        /// does not wrap stays vertically centered against the one that does.
+        /// Text-only rows use a two-column grid: both texts are flexible columns sharing the
+        /// width equally, separated by a gap, so each side wraps inside its own column and
+        /// neither grows into the other. The label is leading-aligned, the value side
+        /// trailing-aligned, and the column that does not wrap stays vertically centered.
+        ///
+        /// Rows carrying a wide adornment (`tag`, `icon` or `button`) keep the legacy
+        /// space-between layout: a 50% column has no room left for the value once a tag and a
+        /// rounded icon sit next to it, and the value would wrap per character. The small
+        /// `imageIcon` (20pt) fits the grid and stays in it.
         @ViewBuilder
         private func getItemView(item: InlineTextListItemParameters.ItemModel) -> some View {
-            HStack(spacing: Ocean.size.spacingStackXxs) {
+            if hasWideAdornment {
+                getLegacyItemView(item: item)
+            } else {
+                getGridItemView(item: item)
+            }
+        }
+
+        private var hasWideAdornment: Bool {
+            parameters.tag != nil || parameters.icon != nil || parameters.button != nil
+        }
+
+        private func getGridItemView(item: InlineTextListItemParameters.ItemModel) -> some View {
+            LabelValueGridRow(text: item.text,
+                              value: item.value,
+                              valueColor: item.valueColor,
+                              isBoldValue: item.isBoldValue,
+                              newValue: item.newValue,
+                              newValueColor: item.newValueColor,
+                              imageIcon: item.imageIcon,
+                              imageColor: item.imageColor)
+        }
+
+        /// Pre-grid layout, kept verbatim for rows with tag / rounded icon / button.
+        @ViewBuilder
+        private func getLegacyItemView(item: InlineTextListItemParameters.ItemModel) -> some View {
+            HStack {
                 Typography.paragraph { label in
                     label.parameters.text = item.text
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
 
-                HStack(spacing: Ocean.size.spacingStackXxs) {
-                    // Adornments keep their intrinsic size: only the texts are the flexible
-                    // grid cells, so a tag or icon never gets squeezed by the value.
-                    if let icon = item.imageIcon {
-                        Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
-                            .resizable()
-                            .renderingMode(.template)
-                            .frame(width: 20, height: 20)
-                            .foregroundColor(Color(item.imageColor))
-                            .fixedSize()
-                    }
+                Spacer()
 
-                    if let tag = parameters.tag {
-                        Tag.init(parameters: tag)
-                            .fixedSize(horizontal: true, vertical: false)
-                    }
-
-                    if !item.newValue.isEmpty, !item.value.isEmpty {
-                        Typography.paragraph { label in
-                            label.parameters.text = item.value
-                            label.parameters.textColor = item.valueColor
-                            label.parameters.strikethrough = true
-                            label.parameters.multilineTextAlignment = .trailing
-                        }
-                        Typography.paragraph { label in
-                            label.parameters.text = item.newValue
-                            label.parameters.textColor = item.newValueColor
-                            label.parameters.multilineTextAlignment = .trailing
-                        }
-                    } else {
-                        Typography.paragraph { label in
-                            label.parameters.text = item.value
-                            label.parameters.textColor = item.valueColor
-                            label.parameters.font = item.isBoldValue
-                            ? .baseBold(size: Ocean.font.fontSizeXs)
-                            : .baseRegular(size: Ocean.font.fontSizeXs)
-                            label.parameters.multilineTextAlignment = .trailing
-                        }
-                    }
-
-                    if let roundedIcon = parameters.icon {
-                        RoundedIcon.init(parameters: roundedIcon)
-                            .fixedSize()
-                    }
-
-                    if let button = parameters.button {
-                        Button.init(parameters: button)
-                            .fixedSize(horizontal: true, vertical: false)
-                    }
+                if let icon = item.imageIcon {
+                    LabelValueImageIcon(icon: icon, color: item.imageColor)
                 }
-                .frame(maxWidth: .infinity, alignment: .trailing)
+
+                if let tag = parameters.tag {
+                    Tag.init(parameters: tag)
+                }
+
+                LabelValueTexts(value: item.value,
+                                valueColor: item.valueColor,
+                                isBoldValue: item.isBoldValue,
+                                newValue: item.newValue,
+                                newValueColor: item.newValueColor,
+                                alignment: .leading)
+
+                if let roundedIcon = parameters.icon {
+                    RoundedIcon.init(parameters: roundedIcon)
+                }
+
+                if let button = parameters.button {
+                    Button.init(parameters: button)
+                        .fixedSize(horizontal: true, vertical: false)
+                }
             }
         }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
@@ -230,16 +230,20 @@ extension OceanSwiftUI {
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack(spacing: Ocean.size.spacingStackXxs) {
+                    // Adornments keep their intrinsic size: only the texts are the flexible
+                    // grid cells, so a tag or icon never gets squeezed by the value.
                     if let icon = item.imageIcon {
                         Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
                             .resizable()
                             .renderingMode(.template)
                             .frame(width: 20, height: 20)
                             .foregroundColor(Color(item.imageColor))
+                            .fixedSize()
                     }
 
                     if let tag = parameters.tag {
                         Tag.init(parameters: tag)
+                            .fixedSize(horizontal: true, vertical: false)
                     }
 
                     if !item.newValue.isEmpty, !item.value.isEmpty {
@@ -267,6 +271,7 @@ extension OceanSwiftUI {
 
                     if let roundedIcon = parameters.icon {
                         RoundedIcon.init(parameters: roundedIcon)
+                            .fixedSize()
                     }
 
                     if let button = parameters.button {

--- a/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+InlineTextListItem.swift
@@ -215,55 +215,66 @@ extension OceanSwiftUI {
             }
         }
 
+        /// Renders a label/value row as a two-column grid.
+        ///
+        /// Both columns are flexible and share the available width equally, separated by a
+        /// gap, so each side wraps inside its own column and neither grows into the other.
+        /// The label is leading-aligned, the value side trailing-aligned, and the column that
+        /// does not wrap stays vertically centered against the one that does.
         @ViewBuilder
         private func getItemView(item: InlineTextListItemParameters.ItemModel) -> some View {
-            HStack {
+            HStack(spacing: Ocean.size.spacingStackXxs) {
                 Typography.paragraph { label in
                     label.parameters.text = item.text
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Spacer()
-
-                if let icon = item.imageIcon {
-                    Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
-                        .resizable()
-                        .renderingMode(.template)
-                        .frame(width: 20, height: 20)
-                        .foregroundColor(Color(item.imageColor))
-                }
-
-                if let tag = parameters.tag {
-                    Tag.init(parameters: tag)
-                }
-
-                if !item.newValue.isEmpty, !item.value.isEmpty {
-                    Typography.paragraph { label in
-                        label.parameters.text = item.value
-                        label.parameters.textColor = item.valueColor
-                        label.parameters.strikethrough = true
+                HStack(spacing: Ocean.size.spacingStackXxs) {
+                    if let icon = item.imageIcon {
+                        Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
+                            .resizable()
+                            .renderingMode(.template)
+                            .frame(width: 20, height: 20)
+                            .foregroundColor(Color(item.imageColor))
                     }
-                    Typography.paragraph { label in
-                        label.parameters.text = item.newValue
-                        label.parameters.textColor = item.newValueColor
-                    }
-                } else {
-                    Typography.paragraph { label in
-                        label.parameters.text = item.value
-                        label.parameters.textColor = item.valueColor
-                        label.parameters.font = item.isBoldValue
-                        ? .baseBold(size: Ocean.font.fontSizeXs)
-                        : .baseRegular(size: Ocean.font.fontSizeXs)
-                    }
-                }
 
-                if let roundedIcon = parameters.icon {
-                    RoundedIcon.init(parameters: roundedIcon)
-                }
+                    if let tag = parameters.tag {
+                        Tag.init(parameters: tag)
+                    }
 
-                if let button = parameters.button {
-                    Button.init(parameters: button)
-                        .fixedSize(horizontal: true, vertical: false)
+                    if !item.newValue.isEmpty, !item.value.isEmpty {
+                        Typography.paragraph { label in
+                            label.parameters.text = item.value
+                            label.parameters.textColor = item.valueColor
+                            label.parameters.strikethrough = true
+                            label.parameters.multilineTextAlignment = .trailing
+                        }
+                        Typography.paragraph { label in
+                            label.parameters.text = item.newValue
+                            label.parameters.textColor = item.newValueColor
+                            label.parameters.multilineTextAlignment = .trailing
+                        }
+                    } else {
+                        Typography.paragraph { label in
+                            label.parameters.text = item.value
+                            label.parameters.textColor = item.valueColor
+                            label.parameters.font = item.isBoldValue
+                            ? .baseBold(size: Ocean.font.fontSizeXs)
+                            : .baseRegular(size: Ocean.font.fontSizeXs)
+                            label.parameters.multilineTextAlignment = .trailing
+                        }
+                    }
+
+                    if let roundedIcon = parameters.icon {
+                        RoundedIcon.init(parameters: roundedIcon)
+                    }
+
+                    if let button = parameters.button {
+                        Button.init(parameters: button)
+                            .fixedSize(horizontal: true, vertical: false)
+                    }
                 }
+                .frame(maxWidth: .infinity, alignment: .trailing)
             }
         }
 

--- a/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+LabelValueGridRow.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/InlineTextListItem/OceanSwiftUI+LabelValueGridRow.swift
@@ -1,0 +1,103 @@
+//
+//  OceanSwiftUI+LabelValueGridRow.swift
+//  OceanComponents
+//
+//  Created by Igor Monteiro on 03/09/2026.
+//
+
+import SwiftUI
+import OceanTokens
+
+extension OceanSwiftUI {
+    /// Two-column label/value row shared by `InlineTextListItem` and `TransactionFooter`.
+    ///
+    /// Both texts are flexible columns sharing the available width equally, separated by a
+    /// gap, so each side wraps inside its own column and neither grows into the other. The
+    /// label is leading-aligned, the value side trailing-aligned, and the column that does
+    /// not wrap stays vertically centered against the one that does. A small leading image
+    /// (20pt) fits the value column and keeps its intrinsic size.
+    struct LabelValueGridRow: View {
+        let text: String
+        let value: String
+        let valueColor: UIColor
+        let isBoldValue: Bool
+        let newValue: String
+        let newValueColor: UIColor
+        let imageIcon: UIImage?
+        let imageColor: UIColor
+
+        var body: some View {
+            HStack(spacing: Ocean.size.spacingStackXxs) {
+                Typography.paragraph { label in
+                    label.parameters.text = text
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: Ocean.size.spacingStackXxs) {
+                    if let icon = imageIcon {
+                        LabelValueImageIcon(icon: icon, color: imageColor)
+                    }
+
+                    LabelValueTexts(value: value,
+                                    valueColor: valueColor,
+                                    isBoldValue: isBoldValue,
+                                    newValue: newValue,
+                                    newValueColor: newValueColor,
+                                    alignment: .trailing)
+                }
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            }
+        }
+    }
+
+    /// The 20pt template image that may precede a value.
+    struct LabelValueImageIcon: View {
+        let icon: UIImage
+        let color: UIColor
+
+        var body: some View {
+            Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
+                .resizable()
+                .renderingMode(.template)
+                .frame(width: 20, height: 20)
+                .foregroundColor(Color(color))
+                .fixedSize()
+        }
+    }
+
+    /// The value block: either a struck-through old value followed by the new one, or a
+    /// single value that may be bold.
+    struct LabelValueTexts: View {
+        let value: String
+        let valueColor: UIColor
+        let isBoldValue: Bool
+        let newValue: String
+        let newValueColor: UIColor
+        let alignment: TextAlignment
+
+        var body: some View {
+            if !newValue.isEmpty, !value.isEmpty {
+                Typography.paragraph { label in
+                    label.parameters.text = value
+                    label.parameters.textColor = valueColor
+                    label.parameters.strikethrough = true
+                    label.parameters.multilineTextAlignment = alignment
+                }
+                Typography.paragraph { label in
+                    label.parameters.text = newValue
+                    label.parameters.textColor = newValueColor
+                    label.parameters.multilineTextAlignment = alignment
+                }
+            } else {
+                Typography.paragraph { label in
+                    label.parameters.text = value
+                    label.parameters.textColor = valueColor
+                    label.parameters.font = isBoldValue
+                    ? .baseBold(size: Ocean.font.fontSizeXs)
+                    : .baseRegular(size: Ocean.font.fontSizeXs)
+                    label.parameters.multilineTextAlignment = alignment
+                }
+            }
+        }
+    }
+}

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -137,43 +137,53 @@ extension OceanSwiftUI {
 
         // MARK: Methods private
 
+        /// Same two-column grid as `InlineTextListItem`'s `item` branch: both texts are
+        /// flexible columns sharing the width equally, separated by a gap, so a long value
+        /// wraps inside its own column instead of growing into the label's. The icon keeps
+        /// its intrinsic size and never squeezes the texts.
         @ViewBuilder
         private func getItemView(item: TransactionFooterParameters.ItemModel) -> some View {
             VStack(alignment: .leading, spacing: 0) {
-                HStack {
+                HStack(spacing: Ocean.size.spacingStackXxs) {
                     Typography.paragraph { label in
                         label.parameters.text = item.text
                     }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                    Spacer()
+                    HStack(spacing: Ocean.size.spacingStackXxs) {
+                        if let icon = item.imageIcon {
+                            Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
+                                .resizable()
+                                .renderingMode(.template)
+                                .frame(width: 20, height: 20)
+                                .foregroundColor(Color(item.imageColor))
+                                .fixedSize()
+                        }
 
-                    if let icon = item.imageIcon {
-                        Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
-                            .resizable()
-                            .renderingMode(.template)
-                            .frame(width: 20, height: 20)
-                            .foregroundColor(Color(item.imageColor))
+                        if !item.newValue.isEmpty, !item.value.isEmpty {
+                            Typography.paragraph { label in
+                                label.parameters.text = item.value
+                                label.parameters.textColor = item.valueColor
+                                label.parameters.strikethrough = true
+                                label.parameters.multilineTextAlignment = .trailing
+                            }
+                            Typography.paragraph { label in
+                                label.parameters.text = item.newValue
+                                label.parameters.textColor = item.newValueColor
+                                label.parameters.multilineTextAlignment = .trailing
+                            }
+                        } else {
+                            Typography.paragraph { label in
+                                label.parameters.text = item.value
+                                label.parameters.textColor = item.valueColor
+                                label.parameters.font = item.isBoldValue
+                                    ? .baseBold(size: Ocean.font.fontSizeXs)
+                                    : .baseRegular(size: Ocean.font.fontSizeXs)
+                                label.parameters.multilineTextAlignment = .trailing
+                            }
+                        }
                     }
-
-                    if !item.newValue.isEmpty, !item.value.isEmpty {
-                        Typography.paragraph { label in
-                            label.parameters.text = item.value
-                            label.parameters.textColor = item.valueColor
-                            label.parameters.strikethrough = true
-                        }
-                        Typography.paragraph { label in
-                            label.parameters.text = item.newValue
-                            label.parameters.textColor = item.newValueColor
-                        }
-                    } else {
-                        Typography.paragraph { label in
-                            label.parameters.text = item.value
-                            label.parameters.textColor = item.valueColor
-                            label.parameters.font = item.isBoldValue
-                                ? .baseBold(size: Ocean.font.fontSizeXs)
-                                : .baseRegular(size: Ocean.font.fontSizeXs)
-                        }
-                    }
+                    .frame(maxWidth: .infinity, alignment: .trailing)
                 }
 
                 if !item.caption.isEmpty {

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -137,54 +137,20 @@ extension OceanSwiftUI {
 
         // MARK: Methods private
 
-        /// Same two-column grid as `InlineTextListItem`'s `item` branch: both texts are
-        /// flexible columns sharing the width equally, separated by a gap, so a long value
-        /// wraps inside its own column instead of growing into the label's. The icon keeps
-        /// its intrinsic size and never squeezes the texts.
+        /// Same two-column grid as `InlineTextListItem`'s text-only rows (shared
+        /// `LabelValueGridRow`): a long value wraps inside its own column instead of growing
+        /// into the label's, and the icon keeps its intrinsic size.
         @ViewBuilder
         private func getItemView(item: TransactionFooterParameters.ItemModel) -> some View {
             VStack(alignment: .leading, spacing: 0) {
-                HStack(spacing: Ocean.size.spacingStackXxs) {
-                    Typography.paragraph { label in
-                        label.parameters.text = item.text
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    HStack(spacing: Ocean.size.spacingStackXxs) {
-                        if let icon = item.imageIcon {
-                            Image(uiImage: icon.withRenderingMode(.alwaysTemplate))
-                                .resizable()
-                                .renderingMode(.template)
-                                .frame(width: 20, height: 20)
-                                .foregroundColor(Color(item.imageColor))
-                                .fixedSize()
-                        }
-
-                        if !item.newValue.isEmpty, !item.value.isEmpty {
-                            Typography.paragraph { label in
-                                label.parameters.text = item.value
-                                label.parameters.textColor = item.valueColor
-                                label.parameters.strikethrough = true
-                                label.parameters.multilineTextAlignment = .trailing
-                            }
-                            Typography.paragraph { label in
-                                label.parameters.text = item.newValue
-                                label.parameters.textColor = item.newValueColor
-                                label.parameters.multilineTextAlignment = .trailing
-                            }
-                        } else {
-                            Typography.paragraph { label in
-                                label.parameters.text = item.value
-                                label.parameters.textColor = item.valueColor
-                                label.parameters.font = item.isBoldValue
-                                    ? .baseBold(size: Ocean.font.fontSizeXs)
-                                    : .baseRegular(size: Ocean.font.fontSizeXs)
-                                label.parameters.multilineTextAlignment = .trailing
-                            }
-                        }
-                    }
-                    .frame(maxWidth: .infinity, alignment: .trailing)
-                }
+                LabelValueGridRow(text: item.text,
+                                  value: item.value,
+                                  valueColor: item.valueColor,
+                                  isBoldValue: item.isBoldValue,
+                                  newValue: item.newValue,
+                                  newValueColor: item.newValueColor,
+                                  imageIcon: item.imageIcon,
+                                  imageColor: item.imageColor)
 
                 if !item.caption.isEmpty {
                     Typography.caption { label in

--- a/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
+++ b/Sources/OceanComponents/ComponentsSwiftUI/TransactionFooter/OceanSwiftUI+TransactionFooter.swift
@@ -19,6 +19,9 @@ extension OceanSwiftUI {
         @Published public var buttonOrientation: ButtonOrientation
         @Published public var showSkeleton: Bool
         @Published public var skeletonLines: Int
+        /// Extra spacing between rows. Rows already carry `spacingStackXxs` of vertical
+        /// padding each (the Figma Inline Text List Item), so with the default `0` two texts
+        /// end up `spacingStackXs` apart, exactly like the design.
         @Published public var interlineSpacing: CGFloat
         @Published public var padding: EdgeInsets
 
@@ -28,7 +31,7 @@ extension OceanSwiftUI {
                     buttonOrientation: ButtonOrientation = .horizontal,
                     showSkeleton: Bool = false,
                     skeletonLines: Int = 3,
-                    interlineSpacing: CGFloat = Ocean.size.spacingStackXxs,
+                    interlineSpacing: CGFloat = 0,
                     padding: EdgeInsets = .init(top: 0,
                                                 leading: Ocean.size.spacingStackXs,
                                                 bottom: Ocean.size.spacingStackXs,
@@ -111,13 +114,20 @@ extension OceanSwiftUI {
         // MARK: View SwiftUI
 
         public var body: some View {
+            // Figma "Transaction Footer": rows are Inline Text List Items (vertical padding
+            // `spacingStackXxs` each, no gap between them) and the button bar sits
+            // `spacingStackXs` below the last row. Without rows the button comes first, so the
+            // rows block is left out instead of contributing an empty view plus the stack spacing.
             VStack(alignment: .leading, spacing: Ocean.size.spacingStackXs) {
                 if parameters.showSkeleton {
                     getSkeletonView(skeletonLines: parameters.skeletonLines)
                 } else {
-                    VStack(spacing: parameters.interlineSpacing) {
-                        ForEach(parameters.items.indices, id: \.self) { index in
-                            getItemView(item: parameters.items[index])
+                    if !parameters.items.isEmpty {
+                        VStack(spacing: parameters.interlineSpacing) {
+                            ForEach(parameters.items.indices, id: \.self) { index in
+                                getItemView(item: parameters.items[index])
+                                    .padding(.vertical, Ocean.size.spacingStackXxs)
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Description

`InlineTextListItem` has two render branches, and only one of them protected the value side. `getItemView()` ends its right-hand `HStack` with `.fixedSize(horizontal: true, vertical: false)`; `getItemView(item:)` — the branch used when `parameters.item` is set, which is what `TransactionFooter` composes — was a bare `HStack` with a `Spacer()` and no `fixedSize`, `layoutPriority` or `lineLimit`. Label and value competed for the available width, so a long value grew into the label's column.

The row is now a two-column grid:

- both sides are flexible columns that share the available width equally, separated by the `spacingStackXxs` gap, so each one wraps inside its own column and adjusts to the screen width;
- the label stays leading-aligned and the value side trailing-aligned;
- the column that does not wrap stays vertically centered against the one that does.

The value side keeps its `HStack` so the icon, tag, rounded icon and button still travel with the value, and its inner spacing is `spacingStackXxs` — the same 8pt the default `HStack` spacing used to provide between those elements, so nothing collapses.

The same grid is applied to `TransactionFooter.getItemView(item:)`, which renders its own `ItemModel` through the old `HStack { label; Spacer(); value }` — so the review screen and the payment-method / billet screens now lay out the same `items` the same way. **Rows with a wide adornment (`tag`, `icon` or `button`) keep the pre-PR space-between layout verbatim** — a 50% column has no room for a value next to a Tag and a RoundedIcon, so those rows render exactly as on `master`. The grid applies to text-only rows, the case the design specified; the small 20pt `imageIcon` fits the value column and stays in the grid. The grid row and the value block are one shared internal `LabelValueGridRow` / `LabelValueTexts`, used by both components.

No public API changes: no new parameter, no changed default. The `title`/`description` branch is untouched.

Fixes #705

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

**Unit tests** — `OceanDesignSystemTests/InlineTextListItemGridTests.swift`. Five **measured layout tests** (`UIHostingController.sizeThatFits(in: 320×∞)`) that fail on `master` without the grid: a long label wraps inside its column; a long value wraps inside its column; a tag + rounded icon row stays a single line (the compression case found in review); a `TransactionFooter` item wraps a long value; the same long label wraps in the grid but never stacks per character once a rounded icon switches the row to the legacy layout. The remaining 15 cases are parameter round-trips that guard the API (`item`, `tag`, `icon`, `button`, `padding`, `showSkeleton`) — they are not layout coverage and are not sold as such. Full suite green: `xcodebuild test -scheme OceanDesignSystem -destination 'platform=iOS Simulator,name=iPhone 17'` → `** TEST SUCCEEDED **`, no new warnings.

**Showcase** — six grid variations added to `InlineTextListItemSwiftUIViewController` under "Grid de duas colunas", and each one checked on the simulator (iPhone 17, iOS 26.5):

| Case | Result |
|---|---|
| short label / short value | one per column, gap in the middle |
| short label / long value | value wraps to two trailing-aligned lines inside its own column, label untouched |
| long label / long value | both columns the same width, two lines each |
| long label / short value | label wraps to three lines, value stays vertically centered against it |
| strikethrough + new value | 8pt gap between the two values preserved |
| with tag | tag and value share the right column, two-line label untouched |

The pre-existing rows on the screen were also checked for regression — icons, tags, buttons and the `title`/`description` rows render as before.

## Screenshots (if appropriate):

Simulator screenshots of the six variations are attached to the Blu-side card (MR-732); the showcase section reproduces them for any reviewer running the project.

## Checklist:

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation (if appropriate)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests passed

## Context for Blu reviewers

Comes from the design QA round on the PagBlu payment flow (`blu-mobile-ios`), card [MR-732](https://useblu.atlassian.net/browse/MR-732) / subtask MR-668, spec in the [MR-732 Ledger](https://github.com/Pagnet/product-bluprints/blob/main/prd-tracking/MR-732-revisao-qa-ios-ajustes-fluxo/MR-732-revisao-qa-ios-ajustes-fluxo-ledger.md). The app pins `exactVersion 3.8.2712`, so it only picks this up after the pin is bumped to the tag this merge produces — tracked as a follow-up on the Blu side.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ocean-ds/ocean-ios/pull/706" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

